### PR TITLE
remove training-related UI elements

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-[ ] remove the play and step buttons (keep the reset button), remove the Epoch
+[x] remove the play and step buttons (keep the reset button), remove the Epoch
     counter, the "Tinker With a Neural Network Right Here in Your Browser"
     header, the Learning Rate dropdown, the Regularization dropdowns, the
     Problem type dropdown, the "Test loss", "Training loss" and the associated

--- a/index.html
+++ b/index.html
@@ -48,11 +48,6 @@ limitations under the License.
       <path class="icon" d="M43.1,5.8c-6.6,0-12,5.4-12,12c0,5.3,3.4,9.8,8.2,11.4c0.6,0.1,0.8-0.3,0.8-0.6c0-0.3,0-1,0-2c-3.3,0.7-4-1.6-4-1.6c-0.5-1.4-1.3-1.8-1.3-1.8c-1.1-0.7,0.1-0.7,0.1-0.7c1.2,0.1,1.8,1.2,1.8,1.2c1.1,1.8,2.8,1.3,3.5,1c0.1-0.8,0.4-1.3,0.8-1.6c-2.7-0.3-5.5-1.3-5.5-5.9c0-1.3,0.5-2.4,1.2-3.2c-0.1-0.3-0.5-1.5,0.1-3.2c0,0,1-0.3,3.3,1.2c1-0.3,2-0.4,3-0.4c1,0,2,0.1,3,0.4c2.3-1.6,3.3-1.2,3.3-1.2c0.7,1.7,0.2,2.9,0.1,3.2c0.8,0.8,1.2,1.9,1.2,3.2c0,4.6-2.8,5.6-5.5,5.9c0.4,0.4,0.8,1.1,0.8,2.2c0,1.6,0,2.9,0,3.3c0,0.3,0.2,0.7,0.8,0.6c4.8-1.6,8.2-6.1,8.2-11.4C55.1,11.2,49.7,5.8,43.1,5.8z"/>
     </svg>
   </a>
-  <!-- Header -->
-  <header>
-    <h1 class="l--page">Tinker With a <b>Neural Network</b> <span class="optional">Right Here </span>in Your Browser.<br>Don’t Worry, You Can’t Break It. We Promise.</h1>
-  </header>
-
   <!-- Top Controls -->
   <div id="top-controls">
     <div class="container l--page">
@@ -60,35 +55,6 @@ limitations under the License.
         <button class="mdl-button mdl-js-button mdl-button--icon ui-resetButton" id="reset-button" title="Reset the network">
           <i class="material-icons">replay</i>
         </button>
-        <button class="mdl-button mdl-js-button mdl-button--fab mdl-button--colored ui-playButton" id="play-pause-button" title="Run/Pause">
-          <i class="material-icons">play_arrow</i>
-          <i class="material-icons">pause</i>
-        </button>
-        <button class="mdl-button mdl-js-button mdl-button--icon ui-stepButton" id="next-step-button" title="Step">
-          <i class="material-icons">skip_next</i>
-        </button>
-      </div>
-      <div class="control">
-        <span class="label">Epoch</span>
-        <span class="value" id="iter-number"></span>
-      </div>
-      <div class="control ui-learningRate">
-        <label for="learningRate">Learning rate</label>
-        <div class="select">
-          <select id="learningRate">
-            <option value="0.00001">0.00001</option>
-            <option value="0.0001">0.0001</option>
-            <option value="0.001">0.001</option>
-            <option value="0.003">0.003</option>
-            <option value="0.01">0.01</option>
-            <option value="0.03">0.03</option>
-            <option value="0.1">0.1</option>
-            <option value="0.3">0.3</option>
-            <option value="1">1</option>
-            <option value="3">3</option>
-            <option value="10">10</option>
-          </select>
-        </div>
       </div>
       <div class="control ui-activation">
         <label for="activations">Activation</label>
@@ -98,42 +64,6 @@ limitations under the License.
             <option value="tanh">Tanh</option>
             <option value="sigmoid">Sigmoid</option>
             <option value="linear">Linear</option>
-          </select>
-        </div>
-      </div>
-      <div class="control ui-regularization">
-        <label for="regularizations">Regularization</label>
-        <div class="select">
-          <select id="regularizations">
-            <option value="none">None</option>
-            <option value="L1">L1</option>
-            <option value="L2">L2</option>
-          </select>
-        </div>
-      </div>
-      <div class="control ui-regularizationRate">
-        <label for="regularRate">Regularization rate</label>
-        <div class="select">
-          <select id="regularRate">
-            <option value="0">0</option>
-            <option value="0.001">0.001</option>
-            <option value="0.003">0.003</option>
-            <option value="0.01">0.01</option>
-            <option value="0.03">0.03</option>
-            <option value="0.1">0.1</option>
-            <option value="0.3">0.3</option>
-            <option value="1">1</option>
-            <option value="3">3</option>
-            <option value="10">10</option>
-          </select>
-        </div>
-      </div>
-      <div class="control ui-problem">
-        <label for="problem">Problem type</label>
-        <div class="select">
-          <select id="problem">
-            <option value="classification">Classification</option>
-            <option value="regression">Regression</option>
           </select>
         </div>
       </div>
@@ -172,24 +102,6 @@ limitations under the License.
         </div>
       </div>
       <div>
-        <div class="ui-percTrainData">
-          <label for="percTrainData">Ratio of training to test data:&nbsp;&nbsp;<span class="value">XX</span>%</label>
-          <p class="slider">
-            <input class="mdl-slider mdl-js-slider" type="range" id="percTrainData" min="10" max="90" step="10">
-          </p>
-        </div>
-        <div class="ui-noise">
-          <label for="noise">Noise:&nbsp;&nbsp;<span class="value">XX</span></label>
-          <p class="slider">
-            <input class="mdl-slider mdl-js-slider" type="range" id="noise" min="0" max="50" step="5">
-          </p>
-        </div>
-        <div class="ui-batchSize">
-          <label for="batchSize">Batch size:&nbsp;&nbsp;<span class="value">XX</span></label>
-          <p class="slider">
-            <input class="mdl-slider mdl-js-slider" type="range" id="batchSize" min="1" max="30" step="1">
-          </p>
-        </div>
           <button class="basic-button" id="data-regen-button" title="Regenerate data">
             Regenerate
           </button>
@@ -263,15 +175,6 @@ limitations under the License.
     <div class="column output">
       <h4>Output</h4>
       <div class="metrics">
-        <div class="output-stats ui-percTrainData">
-          <span>Test loss</span>
-          <div class="value" id="loss-test"></div>
-        </div>
-        <div class="output-stats train">
-          <span>Training loss</span>
-          <div class="value" id="loss-train"></div>
-        </div>
-        <div id="linechart"></div>
       </div>
       <div id="heatmap"></div>
       <div style="float:left;margin-top:20px">
@@ -296,10 +199,6 @@ limitations under the License.
         </div>
         <br/>
         <div style="display:flex;">
-          <label class="ui-showTestData mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="show-test-data">
-            <input type="checkbox" id="show-test-data" class="mdl-checkbox__input" checked>
-            <span class="mdl-checkbox__label label">Show test data</span>
-          </label>
           <label class="ui-discretize mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="discretize">
             <input type="checkbox" id="discretize" class="mdl-checkbox__input" checked>
             <span class="mdl-checkbox__label label">Discretize output</span>

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -73,20 +73,10 @@ let INPUTS: {[name: string]: InputFeature} = {
 };
 
 let HIDABLE_CONTROLS = [
-  ["Show test data", "showTestData"],
   ["Discretize output", "discretize"],
-  ["Play button", "playButton"],
-  ["Step button", "stepButton"],
   ["Reset button", "resetButton"],
-  ["Learning rate", "learningRate"],
   ["Activation", "activation"],
-  ["Regularization", "regularization"],
-  ["Regularization rate", "regularizationRate"],
-  ["Problem type", "problem"],
   ["Which dataset", "dataset"],
-  ["Ratio train data", "percTrainData"],
-  ["Noise level", "noise"],
-  ["Batch size", "batchSize"],
   ["# of hidden layers", "numHiddenLayers"],
 ];
 
@@ -179,26 +169,6 @@ function makeGUI() {
   d3.select("#reset-button").on("click", () => {
     reset();
     userHasInteracted();
-    d3.select("#play-pause-button");
-  });
-
-  d3.select("#play-pause-button").on("click", function () {
-    // Change the button's content.
-    userHasInteracted();
-    player.playOrPause();
-  });
-
-  player.onPlayPause(isPlaying => {
-    d3.select("#play-pause-button").classed("playing", isPlaying);
-  });
-
-  d3.select("#next-step-button").on("click", () => {
-    player.pause();
-    userHasInteracted();
-    if (iter === 0) {
-      simulationStarted();
-    }
-    oneStep();
   });
 
   d3.select("#data-regen-button").on("click", () => {
@@ -264,15 +234,6 @@ function makeGUI() {
     reset();
   });
 
-  let showTestData = d3.select("#show-test-data").on("change", function() {
-    state.showTestData = this.checked;
-    state.serialize();
-    userHasInteracted();
-    heatMap.updateTestPoints(state.showTestData ? testData : []);
-  });
-  // Check/uncheck the checkbox according to the current state.
-  showTestData.property("checked", state.showTestData);
-
   let discretize = d3.select("#discretize").on("change", function() {
     state.discretize = this.checked;
     state.serialize();
@@ -282,45 +243,6 @@ function makeGUI() {
   // Check/uncheck the checbox according to the current state.
   discretize.property("checked", state.discretize);
 
-  let percTrain = d3.select("#percTrainData").on("input", function() {
-    state.percTrainData = this.value;
-    d3.select("label[for='percTrainData'] .value").text(this.value);
-    generateData();
-    parametersChanged = true;
-    reset();
-  });
-  percTrain.property("value", state.percTrainData);
-  d3.select("label[for='percTrainData'] .value").text(state.percTrainData);
-
-  let noise = d3.select("#noise").on("input", function() {
-    state.noise = this.value;
-    d3.select("label[for='noise'] .value").text(this.value);
-    generateData();
-    parametersChanged = true;
-    reset();
-  });
-  let currentMax = parseInt(noise.property("max"));
-  if (state.noise > currentMax) {
-    if (state.noise <= 80) {
-      noise.property("max", state.noise);
-    } else {
-      state.noise = 50;
-    }
-  } else if (state.noise < 0) {
-    state.noise = 0;
-  }
-  noise.property("value", state.noise);
-  d3.select("label[for='noise'] .value").text(state.noise);
-
-  let batchSize = d3.select("#batchSize").on("input", function() {
-    state.batchSize = this.value;
-    d3.select("label[for='batchSize'] .value").text(this.value);
-    parametersChanged = true;
-    reset();
-  });
-  batchSize.property("value", state.batchSize);
-  d3.select("label[for='batchSize'] .value").text(state.batchSize);
-
   let activationDropdown = d3.select("#activations").on("change", function() {
     state.activation = activations[this.value];
     parametersChanged = true;
@@ -328,39 +250,6 @@ function makeGUI() {
   });
   activationDropdown.property("value",
       getKeyFromValue(activations, state.activation));
-
-  let learningRate = d3.select("#learningRate").on("change", function() {
-    state.learningRate = +this.value;
-    state.serialize();
-    userHasInteracted();
-    parametersChanged = true;
-  });
-  learningRate.property("value", state.learningRate);
-
-  let regularDropdown = d3.select("#regularizations").on("change",
-      function() {
-    state.regularization = regularizations[this.value];
-    parametersChanged = true;
-    reset();
-  });
-  regularDropdown.property("value",
-      getKeyFromValue(regularizations, state.regularization));
-
-  let regularRate = d3.select("#regularRate").on("change", function() {
-    state.regularizationRate = +this.value;
-    parametersChanged = true;
-    reset();
-  });
-  regularRate.property("value", state.regularizationRate);
-
-  let problem = d3.select("#problem").on("change", function() {
-    state.problem = problems[this.value];
-    generateData();
-    drawDatasetThumbnails();
-    parametersChanged = true;
-    reset();
-  });
-  problem.property("value", getKeyFromValue(problems, state.problem));
 
   // Add scale to the gradient color map.
   let x = d3.scale.linear().domain([-1, 1]).range([0, 144]);
@@ -880,9 +769,6 @@ function updateUI(firstStep = false) {
   }
 
   // Update loss and iteration number.
-  d3.select("#loss-train").text(humanReadable(lossTrain));
-  d3.select("#loss-test").text(humanReadable(lossTest));
-  d3.select("#iter-number").text(addCommas(zeroPad(iter)));
   lineChart.addDataPoint([lossTrain, lossTest]);
 }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -162,9 +162,6 @@ let network: nn.Node[][] = null;
 let lossTrain = 0;
 let lossTest = 0;
 let player = new Player();
-// The #linechart div was removed, so this would cause an error.
-// let lineChart = new AppendingLineChart(d3.select("#linechart"),
-//     ["#777", "black"]);
 
 function makeGUI() {
   d3.select("#reset-button").on("click", () => {
@@ -768,9 +765,6 @@ function updateUI(firstStep = false) {
   function humanReadable(n: number): string {
     return n.toFixed(3);
   }
-
-  // Update loss and iteration number.
-  // lineChart.addDataPoint([lossTrain, lossTest]);
 }
 
 function constructInputIds(): string[] {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -162,8 +162,9 @@ let network: nn.Node[][] = null;
 let lossTrain = 0;
 let lossTest = 0;
 let player = new Player();
-let lineChart = new AppendingLineChart(d3.select("#linechart"),
-    ["#777", "black"]);
+// The #linechart div was removed, so this would cause an error.
+// let lineChart = new AppendingLineChart(d3.select("#linechart"),
+//     ["#777", "black"]);
 
 function makeGUI() {
   d3.select("#reset-button").on("click", () => {
@@ -769,7 +770,7 @@ function updateUI(firstStep = false) {
   }
 
   // Update loss and iteration number.
-  lineChart.addDataPoint([lossTrain, lossTest]);
+  // lineChart.addDataPoint([lossTrain, lossTest]);
 }
 
 function constructInputIds(): string[] {
@@ -824,7 +825,7 @@ export function getOutputWeights(network: nn.Node[][]): number[] {
 }
 
 function reset(onStartup=false) {
-  lineChart.reset();
+  // lineChart.reset();
   state.serialize();
   if (!onStartup) {
     userHasInteracted();

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -80,57 +80,6 @@ let HIDABLE_CONTROLS = [
   ["# of hidden layers", "numHiddenLayers"],
 ];
 
-class Player {
-  private timerIndex = 0;
-  private isPlaying = false;
-  private callback: (isPlaying: boolean) => void = null;
-
-  /** Plays/pauses the player. */
-  playOrPause() {
-    if (this.isPlaying) {
-      this.isPlaying = false;
-      this.pause();
-    } else {
-      this.isPlaying = true;
-      if (iter === 0) {
-        simulationStarted();
-      }
-      this.play();
-    }
-  }
-
-  onPlayPause(callback: (isPlaying: boolean) => void) {
-    this.callback = callback;
-  }
-
-  play() {
-    this.pause();
-    this.isPlaying = true;
-    if (this.callback) {
-      this.callback(this.isPlaying);
-    }
-    this.start(this.timerIndex);
-  }
-
-  pause() {
-    this.timerIndex++;
-    this.isPlaying = false;
-    if (this.callback) {
-      this.callback(this.isPlaying);
-    }
-  }
-
-  private start(localTimerIndex: number) {
-    d3.timer(() => {
-      if (localTimerIndex < this.timerIndex) {
-        return true;  // Done.
-      }
-      oneStep();
-      return false;  // Not done.
-    }, 0);
-  }
-}
-
 let state = State.deserializeState();
 
 // Filter out inputs that are hidden.
@@ -161,7 +110,6 @@ let testData: Example2D[] = [];
 let network: nn.Node[][] = null;
 let lossTrain = 0;
 let lossTest = 0;
-let player = new Player();
 
 function makeGUI() {
   d3.select("#reset-button").on("click", () => {
@@ -752,19 +700,6 @@ function updateUI(firstStep = false) {
     data.heatmap.updateBackground(reduceMatrix(boundary[data.id], 10),
         state.discretize);
   });
-
-  function zeroPad(n: number): string {
-    let pad = "000000";
-    return (pad + n).slice(-pad.length);
-  }
-
-  function addCommas(s: string): string {
-    return s.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  }
-
-  function humanReadable(n: number): string {
-    return n.toFixed(3);
-  }
 }
 
 function constructInputIds(): string[] {
@@ -824,7 +759,6 @@ function reset(onStartup=false) {
   if (!onStartup) {
     userHasInteracted();
   }
-  player.pause();
 
   let suffix = state.numHiddenLayers !== 1 ? "s" : "";
   d3.select("#layers-label").text("Hidden layer" + suffix);


### PR DESCRIPTION
By [Google Jules](https://jules.google.com/task/3996367762680614618).

Remove specified UI elements and associated logic

This commit removes the following UI elements as per the TODO list:
- Play and step buttons
- Epoch counter
- Main header
- Learning Rate dropdown
- Regularization dropdowns
- Problem type dropdown
- Test loss, Training loss, and associated graph
- Ratio of training to test data slider
- Noise slider
- Batch size slider
- Show test data button

The corresponding logic in `src/playground.ts` has also been removed or updated.