### PR TITLE
Make output node bias editable and update TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -5,7 +5,7 @@
     graph, the "Ratio of training to test data" slider, the "Noise" slider, the
     "Batch size" slider, and the "Show test data" button.
 [ ] make the reset button set all the weights to zero.
-[ ] make the output's bias editable. currently there are no rectangles we can
+[x] make the output's bias editable. currently there are no rectangles we can
     click to edit the bias.
 [ ] make it easier to edit the weights and bias by hand: instead of clicking to
     enable the edit box where we need to type the new value for the weight or

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -256,7 +256,7 @@ function updateWeightsUI(network: nn.Node[][], container) {
 }
 
 function drawNode(cx: number, cy: number, nodeId: string, isInput: boolean,
-    container, node?: nn.Node) {
+    container, node?: nn.Node, biasOnly = false) {
   let x = cx - RECT_SIZE / 2;
   let y = cy - RECT_SIZE / 2;
 
@@ -267,55 +267,58 @@ function drawNode(cx: number, cy: number, nodeId: string, isInput: boolean,
       "transform": `translate(${x},${y})`
     });
 
-  // Draw the main rectangle.
-  nodeGroup.append("rect")
-    .attr({
-      x: 0,
-      y: 0,
-      width: RECT_SIZE,
-      height: RECT_SIZE,
-    });
-  let activeOrNotClass = state[nodeId] ? "active" : "inactive";
-  if (isInput) {
-    let label = INPUTS[nodeId].label != null ?
-        INPUTS[nodeId].label : nodeId;
-    // Draw the input label.
-    let text = nodeGroup.append("text").attr({
-      class: "main-label",
-      x: -10,
-      y: RECT_SIZE / 2, "text-anchor": "end"
-    });
-    if (/[_^]/.test(label)) {
-      let myRe = /(.*?)([_^])(.)/g;
-      let myArray;
-      let lastIndex;
-      while ((myArray = myRe.exec(label)) != null) {
-        lastIndex = myRe.lastIndex;
-        let prefix = myArray[1];
-        let sep = myArray[2];
-        let suffix = myArray[3];
-        if (prefix) {
-          text.append("tspan").text(prefix);
+  if (!biasOnly) {
+    // Draw the main rectangle.
+    nodeGroup.append("rect")
+      .attr({
+        x: 0,
+        y: 0,
+        width: RECT_SIZE,
+        height: RECT_SIZE,
+      });
+    let activeOrNotClass = state[nodeId] ? "active" : "inactive";
+    if (isInput) {
+      let label = INPUTS[nodeId].label != null ?
+          INPUTS[nodeId].label : nodeId;
+      // Draw the input label.
+      let text = nodeGroup.append("text").attr({
+        class: "main-label",
+        x: -10,
+        y: RECT_SIZE / 2, "text-anchor": "end"
+      });
+      if (/[_^]/.test(label)) {
+        let myRe = /(.*?)([_^])(.)/g;
+        let myArray;
+        let lastIndex;
+        while ((myArray = myRe.exec(label)) != null) {
+          lastIndex = myRe.lastIndex;
+          let prefix = myArray[1];
+          let sep = myArray[2];
+          let suffix = myArray[3];
+          if (prefix) {
+            text.append("tspan").text(prefix);
+          }
+          text.append("tspan")
+          .attr("baseline-shift", sep === "_" ? "sub" : "super")
+          .style("font-size", "9px")
+          .text(suffix);
         }
-        text.append("tspan")
-        .attr("baseline-shift", sep === "_" ? "sub" : "super")
-        .style("font-size", "9px")
-        .text(suffix);
+        if (label.substring(lastIndex)) {
+          text.append("tspan").text(label.substring(lastIndex));
+        }
+      } else {
+        text.append("tspan").text(label);
       }
-      if (label.substring(lastIndex)) {
-        text.append("tspan").text(label.substring(lastIndex));
-      }
-    } else {
-      text.append("tspan").text(label);
+      nodeGroup.classed(activeOrNotClass, true);
     }
-    nodeGroup.classed(activeOrNotClass, true);
   }
+
   if (!isInput) {
     // Draw the node's bias.
     nodeGroup.append("rect")
       .attr({
         id: `bias-${nodeId}`,
-        x: -BIAS_SIZE - 2,
+        x: -BIAS_SIZE * 2 - 4,
         y: RECT_SIZE - BIAS_SIZE + 3,
         width: BIAS_SIZE,
         height: BIAS_SIZE,
@@ -326,47 +329,49 @@ function drawNode(cx: number, cy: number, nodeId: string, isInput: boolean,
       });
   }
 
-  // Draw the node's canvas.
-  let div = d3.select("#network").insert("div", ":first-child")
-    .attr({
-      "id": `canvas-${nodeId}`,
-      "class": "canvas"
-    })
-    .style({
-      position: "absolute",
-      left: `${x + 3}px`,
-      top: `${y + 3}px`
-    })
-    .on("mouseenter", function() {
-      selectedNodeId = nodeId;
-      div.classed("hovered", true);
-      nodeGroup.classed("hovered", true);
-      updateDecisionBoundary(network, false);
-      heatMap.updateBackground(boundary[nodeId], state.discretize);
-    })
-    .on("mouseleave", function() {
-      selectedNodeId = null;
-      div.classed("hovered", false);
-      nodeGroup.classed("hovered", false);
-      updateDecisionBoundary(network, false);
-      heatMap.updateBackground(boundary[nn.getOutputNode(network).id],
-          state.discretize);
-    });
-  if (isInput) {
-    div.on("click", function() {
-      state[nodeId] = !state[nodeId];
-      parametersChanged = true;
-      reset();
-    });
-    div.style("cursor", "pointer");
+  if (!biasOnly) {
+    // Draw the node's canvas.
+    let div = d3.select("#network").insert("div", ":first-child")
+      .attr({
+        "id": `canvas-${nodeId}`,
+        "class": "canvas"
+      })
+      .style({
+        position: "absolute",
+        left: `${x + 3}px`,
+        top: `${y + 3}px`
+      })
+      .on("mouseenter", function() {
+        selectedNodeId = nodeId;
+        div.classed("hovered", true);
+        nodeGroup.classed("hovered", true);
+        updateDecisionBoundary(network, false);
+        heatMap.updateBackground(boundary[nodeId], state.discretize);
+      })
+      .on("mouseleave", function() {
+        selectedNodeId = null;
+        div.classed("hovered", false);
+        nodeGroup.classed("hovered", false);
+        updateDecisionBoundary(network, false);
+        heatMap.updateBackground(boundary[nn.getOutputNode(network).id],
+            state.discretize);
+      });
+    if (isInput) {
+      div.on("click", function() {
+        state[nodeId] = !state[nodeId];
+        parametersChanged = true;
+        reset();
+      });
+      div.style("cursor", "pointer");
+    }
+    let activeOrNotClass = state[nodeId] ? "active" : "inactive";
+    if (isInput) {
+      div.classed(activeOrNotClass, true);
+    }
+    let nodeHeatMap = new HeatMap(RECT_SIZE, DENSITY / 10, xDomain,
+        xDomain, div, {noSvg: true});
+    div.datum({heatmap: nodeHeatMap, id: nodeId});
   }
-  if (isInput) {
-    div.classed(activeOrNotClass, true);
-  }
-  let nodeHeatMap = new HeatMap(RECT_SIZE, DENSITY / 10, xDomain,
-      xDomain, div, {noSvg: true});
-  div.datum({heatmap: nodeHeatMap, id: nodeId});
-
 }
 
 // Draw network
@@ -471,7 +476,7 @@ function drawNetwork(network: nn.Node[][]): void {
   let node = network[numLayers - 1][0];
   let cy = nodeIndexScale(0) + RECT_SIZE / 2;
   node2coord[node.id] = {cx, cy};
-  drawNode(cx, cy, node.id, false, container, node);
+  drawNode(cx, cy, node.id, false, container, node, true);
   // Draw links.
   for (let i = 0; i < node.inputLinks.length; i++) {
     let link = node.inputLinks[i];

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -471,6 +471,7 @@ function drawNetwork(network: nn.Node[][]): void {
   let node = network[numLayers - 1][0];
   let cy = nodeIndexScale(0) + RECT_SIZE / 2;
   node2coord[node.id] = {cx, cy};
+  drawNode(cx, cy, node.id, false, container, node);
   // Draw links.
   for (let i = 0; i < node.inputLinks.length; i++) {
     let link = node.inputLinks[i];


### PR DESCRIPTION
From Google Jules:

- Modified `drawNetwork` to call `drawNode` for the output node, enabling its bias to be drawn and made interactive.
- Verified that `updateHoverCard` correctly handles bias updates for the output node.
- Marked the corresponding TODO item as done.