### PR TITLE
Implement click-and-drag to adjust weights and biases

### DIFF
--- a/TODO
+++ b/TODO
@@ -7,7 +7,7 @@
 [ ] make the reset button set all the weights to zero.
 [x] make the output's bias editable. currently there are no rectangles we can
     click to edit the bias.
-[ ] make it easier to edit the weights and bias by hand: instead of clicking to
+[x] make it easier to edit the weights and bias by hand: instead of clicking to
     enable the edit box where we need to type the new value for the weight or
     bias, let the user click-and-drag to smoothly adjust the value.
 [ ] hit shift while click-and-dragging to snap to the nearest 0.1 increment.

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -584,6 +584,13 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
 
   // Event listener for starting drag
   hovercard.on("pointerdown.drag", (event: PointerEvent) => {
+    console.log("Hovercard pointerdown triggered.", {
+      pointerType: event.pointerType,
+      clientY: event.clientY,
+      target: event.target,
+      currentTarget: event.currentTarget
+    });
+
     // Check if the event target is the hovercard itself or its children, but not the input field
     if (event.target !== hovercard.select("input").node()) {
       isDragging = true;
@@ -596,6 +603,8 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
       event.preventDefault(); // Still useful for desktop and some mobile side-effects
       hovercard.style("cursor", "ns-resize");
       hovercard.style("touch-action", "none"); // Critical for preventing scroll on mobile
+      console.log("Set touch-action: none on hovercard.", hovercard.node().style.touchAction);
+
 
       // Add move and up listeners to the window to capture events globally
       d3.select(window)
@@ -606,8 +615,8 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
           let dy = startY - currentY; // Inverted Y-axis for intuitive dragging (drag up = increase)
           let newValue = initialValue + dy / DRAG_SENSITIVITY;
 
-          // Clamp or round if necessary, here just using precision
           newValue = parseFloat(newValue.toPrecision(2));
+          console.log("Window pointermove:", { currentY, dy, newValue });
 
 
           if (type === HoverType.WEIGHT) {
@@ -620,10 +629,12 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
           updateUI();
         })
         .on("pointerup.drag", (e: PointerEvent) => {
+          console.log("Window pointerup triggered.", { pointerType: e.pointerType });
           if (!isDragging) return;
           isDragging = false;
           hovercard.style("cursor", "ns-resize");
           hovercard.style("touch-action", "auto"); // Restore default touch behavior
+          console.log("Restored touch-action: auto on hovercard.", hovercard.node().style.touchAction);
           // Remove global listeners
           d3.select(window).on("pointermove.drag", null).on("pointerup.drag", null);
           // Potentially call updateUI() again if needed, though it's called on move

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -593,14 +593,15 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
         (nodeOrLink as nn.Node).bias;
 
       // Prevent text selection and default drag behaviors
-      event.preventDefault();
+      event.preventDefault(); // Still useful for desktop and some mobile side-effects
       hovercard.style("cursor", "ns-resize");
+      hovercard.style("touch-action", "none"); // Critical for preventing scroll on mobile
 
       // Add move and up listeners to the window to capture events globally
       d3.select(window)
         .on("pointermove.drag", (e: PointerEvent) => {
           if (!isDragging) return;
-          e.preventDefault();
+          e.preventDefault(); // Prevent default actions during move as well
           let currentY = e.clientY;
           let dy = startY - currentY; // Inverted Y-axis for intuitive dragging (drag up = increase)
           let newValue = initialValue + dy / DRAG_SENSITIVITY;
@@ -622,6 +623,7 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
           if (!isDragging) return;
           isDragging = false;
           hovercard.style("cursor", "ns-resize");
+          hovercard.style("touch-action", "auto"); // Restore default touch behavior
           // Remove global listeners
           d3.select(window).on("pointermove.drag", null).on("pointerup.drag", null);
           // Potentially call updateUI() again if needed, though it's called on move

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -548,30 +548,20 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
   let hovercard = d3.select("#hovercard");
   if (type == null) {
     hovercard.style("display", "none");
-    d3.select("#svg").on("click", null);
+    d3.select("#svg").on("pointerdown", null); // Changed from "click"
     return;
   }
-  d3.select("#svg").on("click", () => {
-    hovercard.select(".value").style("display", "none");
-    let input = hovercard.select("input");
-    input.style("display", null);
-    input.on("input", function() {
-      if (this.value != null && this.value !== "") {
-        if (type === HoverType.WEIGHT) {
-          (nodeOrLink as nn.Link).weight = +this.value;
-        } else {
-          (nodeOrLink as nn.Node).bias = +this.value;
-        }
-        updateUI();
-      }
-    });
-    input.on("keypress", () => {
-      if ((d3.event as any).keyCode === 13) {
-        updateHoverCard(type, nodeOrLink, coordinates);
-      }
-    });
-    (input.node() as HTMLInputElement).focus();
-  });
+
+  // Store initial value and position for dragging
+  let initialValue = (type === HoverType.WEIGHT) ?
+    (nodeOrLink as nn.Link).weight :
+    (nodeOrLink as nn.Node).bias;
+  let isDragging = false;
+  let startY = 0;
+
+  const DRAG_SENSITIVITY = 50; // Pixels per unit value change (inverted: lower is more sensitive)
+
+  // Show hovercard
   let value = (type === HoverType.WEIGHT) ?
     (nodeOrLink as nn.Link).weight :
     (nodeOrLink as nn.Node).bias;
@@ -579,15 +569,69 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
   hovercard.style({
     "left": `${coordinates[0] + 20}px`,
     "top": `${coordinates[1]}px`,
-    "display": "block"
+    "display": "block",
+    "cursor": "ns-resize" // Indicate draggable
   });
   hovercard.select(".type").text(name);
   hovercard.select(".value")
     .style("display", null)
     .text(value.toPrecision(2));
-  hovercard.select("input")
-    .property("value", value.toPrecision(2))
+  hovercard.select("input") // Hide the input field by default
     .style("display", "none");
+  // Update the hovercard text to reflect the new interaction
+  hovercard.select("div[style='font-size:10px']").text("Click and drag to edit.");
+
+
+  // Event listener for starting drag
+  hovercard.on("pointerdown.drag", (event: PointerEvent) => {
+    // Check if the event target is the hovercard itself or its children, but not the input field
+    if (event.target !== hovercard.select("input").node()) {
+      isDragging = true;
+      startY = event.clientY;
+      initialValue = (type === HoverType.WEIGHT) ?
+        (nodeOrLink as nn.Link).weight :
+        (nodeOrLink as nn.Node).bias;
+
+      // Prevent text selection and default drag behaviors
+      event.preventDefault();
+      hovercard.style("cursor", "ns-resize");
+
+      // Add move and up listeners to the window to capture events globally
+      d3.select(window)
+        .on("pointermove.drag", (e: PointerEvent) => {
+          if (!isDragging) return;
+          e.preventDefault();
+          let currentY = e.clientY;
+          let dy = startY - currentY; // Inverted Y-axis for intuitive dragging (drag up = increase)
+          let newValue = initialValue + dy / DRAG_SENSITIVITY;
+
+          // Clamp or round if necessary, here just using precision
+          newValue = parseFloat(newValue.toPrecision(2));
+
+
+          if (type === HoverType.WEIGHT) {
+            (nodeOrLink as nn.Link).weight = newValue;
+          } else {
+            (nodeOrLink as nn.Node).bias = newValue;
+          }
+          // Update hovercard value display
+          hovercard.select(".value").text(newValue.toPrecision(2));
+          updateUI();
+        })
+        .on("pointerup.drag", (e: PointerEvent) => {
+          if (!isDragging) return;
+          isDragging = false;
+          hovercard.style("cursor", "ns-resize");
+          // Remove global listeners
+          d3.select(window).on("pointermove.drag", null).on("pointerup.drag", null);
+          // Potentially call updateUI() again if needed, though it's called on move
+        });
+    }
+  });
+
+
+  // Remove the old d3.select("#svg").on("click", ...) logic
+  // The new logic is self-contained within pointerdown on the hovercard
 }
 
 function drawLink(


### PR DESCRIPTION
From Google Jules:

This change makes it easier to edit weights and biases by allowing users to click and drag on the hovercard to smoothly adjust values.

Previously, users had to click to enable an input box and then type the desired value. The new click-and-drag interaction is more intuitive and supports touch devices through the use of pointer events.

The hovercard's instructional text has been updated to reflect this new interaction model. The core logic resides in the `updateHoverCard` function in `src/playground.ts`.