### PR TITLE
Add node.range and move ActivationFunction to new module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,2 @@
 - When choosing a branch name, please use a prefix which identifies you, the AI agent. For example, Google Jules should use branches which start with `jules/`, GitHub Copilot should use branches which start with `copilot/`, etc.
-- Do not modify `package-lock.json`. The build process may rely on globally installed or otherwise available dependencies not explicitly listed in `package.json`.
+- Try not to modify `package.json` nor `package-lock.json`. The current dependencies should be more than enough.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+- When choosing a branch name, please use a prefix which identifies you, the AI agent. For example, Google Jules should use branches which start with `jules/`, GitHub Copilot should use branches which start with `copilot/`, etc.
+- Do not modify `package-lock.json`. The build process may rely on globally installed or otherwise available dependencies not explicitly listed in `package.json`.

--- a/TODO
+++ b/TODO
@@ -8,7 +8,7 @@
 
 [x] write a function activationRange which takes the activation function (in the same format as in the application's state) and applies the correct reluRange-like function to the input Range.
 
-[ ] add a `node.range` field
+[x] add a `node.range` field
 
 [ ] write a function updateNodeRanges which sets the `node.range` for each node in `state.network:
     

--- a/src/activation.ts
+++ b/src/activation.ts
@@ -1,0 +1,58 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/** A node's activation function and its derivative. */
+export interface ActivationFunction {
+  output: (input: number) => number;
+  der: (input: number) => number;
+}
+
+/** Polyfill for TANH */
+(Math as any).tanh = (Math as any).tanh || function(x) {
+  if (x === Infinity) {
+    return 1;
+  } else if (x === -Infinity) {
+    return -1;
+  } else {
+    let e2x = Math.exp(2 * x);
+    return (e2x - 1) / (e2x + 1);
+  }
+};
+
+/** Built-in activation functions */
+export class Activations {
+  public static TANH: ActivationFunction = {
+    output: x => (Math as any).tanh(x),
+    der: x => {
+      let output = Activations.TANH.output(x);
+      return 1 - output * output;
+    }
+  };
+  public static RELU: ActivationFunction = {
+    output: x => Math.max(0, x),
+    der: x => x <= 0 ? 0 : 1
+  };
+  public static SIGMOID: ActivationFunction = {
+    output: x => 1 / (1 + Math.exp(-x)),
+    der: x => {
+      let output = Activations.SIGMOID.output(x);
+      return output * (1 - output);
+    }
+  };
+  public static LINEAR: ActivationFunction = {
+    output: x => x,
+    der: x => 1
+  };
+}

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {ActivationFunction} from "./activation";
+import {Range} from "./range";
 
 /**
  * A node in a neural network. Each node has a state
@@ -44,6 +46,8 @@ export class Node {
   numAccumulatedDers = 0;
   /** Activation function that takes total input and returns node's output */
   activation: ActivationFunction;
+  /** Range of possible outputs of this node. */
+  range: Range;
 
   /**
    * Creates a new node with the provided id and activation function.
@@ -77,12 +81,6 @@ export interface ErrorFunction {
   der: (output: number, target: number) => number;
 }
 
-/** A node's activation function and its derivative. */
-export interface ActivationFunction {
-  output: (input: number) => number;
-  der: (input: number) => number;
-}
-
 /** Function that computes a penalty cost for a given weight in the network. */
 export interface RegularizationFunction {
   output: (weight: number) => number;
@@ -95,44 +93,6 @@ export class Errors {
     error: (output: number, target: number) =>
                0.5 * Math.pow(output - target, 2),
     der: (output: number, target: number) => output - target
-  };
-}
-
-/** Polyfill for TANH */
-(Math as any).tanh = (Math as any).tanh || function(x) {
-  if (x === Infinity) {
-    return 1;
-  } else if (x === -Infinity) {
-    return -1;
-  } else {
-    let e2x = Math.exp(2 * x);
-    return (e2x - 1) / (e2x + 1);
-  }
-};
-
-/** Built-in activation functions */
-export class Activations {
-  public static TANH: ActivationFunction = {
-    output: x => (Math as any).tanh(x),
-    der: x => {
-      let output = Activations.TANH.output(x);
-      return 1 - output * output;
-    }
-  };
-  public static RELU: ActivationFunction = {
-    output: x => Math.max(0, x),
-    der: x => x <= 0 ? 0 : 1
-  };
-  public static SIGMOID: ActivationFunction = {
-    output: x => 1 / (1 + Math.exp(-x)),
-    der: x => {
-      let output = Activations.SIGMOID.output(x);
-      return output * (1 - output);
-    }
-  };
-  public static LINEAR: ActivationFunction = {
-    output: x => x,
-    der: x => 1
   };
 }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import * as nn from "./nn";
+import { ActivationFunction, Activations } from "./activation";
 import {HeatMap, reduceMatrix} from "./heatmap";
 import {
   State,
@@ -1104,7 +1105,7 @@ function reset(onStartup=false, hardcodeWeights=false) {
   let numInputs = constructInput(0 , 0).length;
   let shape = [numInputs].concat(state.networkShape).concat([1]);
   let outputActivation = (state.problem === Problem.REGRESSION) ?
-      nn.Activations.LINEAR : nn.Activations.TANH;
+      Activations.LINEAR : Activations.TANH;
   network = nn.buildNetwork(shape, state.activation, outputActivation,
       state.regularization, constructInputIds(), state.initZero);
 

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,4 +1,4 @@
-import * as nn from "./nn"; // For Activations
+import {Activations, ActivationFunction} from "./activation";
 
 /**
  * A tuple of two numbers, representing a range [min, max].
@@ -26,35 +26,35 @@ export function addRange(range1: Range, range2: Range): Range {
  * Applies ReLU to both the min and max of the range.
  */
 export function reluRange(range: Range): Range {
-  return [nn.Activations.RELU.output(range[0]), nn.Activations.RELU.output(range[1])];
+  return [Activations.RELU.output(range[0]), Activations.RELU.output(range[1])];
 }
 
 /**
  * Applies tanh to both the min and max of the range.
  */
 export function tanhRange(range: Range): Range {
-  return [nn.Activations.TANH.output(range[0]), nn.Activations.TANH.output(range[1])];
+  return [Activations.TANH.output(range[0]), Activations.TANH.output(range[1])];
 }
 
 /**
  * Applies sigmoid to both the min and max of the range.
  */
 export function sigmoidRange(range: Range): Range {
-  return [nn.Activations.SIGMOID.output(range[0]), nn.Activations.SIGMOID.output(range[1])];
+  return [Activations.SIGMOID.output(range[0]), Activations.SIGMOID.output(range[1])];
 }
 
 /**
  * Applies the given activation function to the range.
  */
 export function activationRange(
-    activation: nn.ActivationFunction, range: Range): Range {
-  if (activation === nn.Activations.RELU) {
+    activation: ActivationFunction, range: Range): Range {
+  if (activation === Activations.RELU) {
     return reluRange(range);
-  } else if (activation === nn.Activations.TANH) {
+  } else if (activation === Activations.TANH) {
     return tanhRange(range);
-  } else if (activation === nn.Activations.SIGMOID) {
+  } else if (activation === Activations.SIGMOID) {
     return sigmoidRange(range);
-  } else if (activation === nn.Activations.LINEAR) {
+  } else if (activation === Activations.LINEAR) {
     return range; // Linear activation doesn't change the range
   } else {
     // Should not happen with existing activation functions

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,16 +15,17 @@ limitations under the License.
 
 import * as nn from "./nn";
 import * as dataset from "./dataset";
+import { ActivationFunction, Activations } from "./activation";
 
 /** Suffix added to the state when storing if a control is hidden or not. */
 const HIDE_STATE_SUFFIX = "_hide";
 
 /** A map between names and activation functions. */
-export let activations: {[key: string]: nn.ActivationFunction} = {
-  "relu": nn.Activations.RELU,
-  "tanh": nn.Activations.TANH,
-  "sigmoid": nn.Activations.SIGMOID,
-  "linear": nn.Activations.LINEAR
+export let activations: {[key: string]: ActivationFunction} = {
+  "relu": Activations.RELU,
+  "tanh": Activations.TANH,
+  "sigmoid": Activations.SIGMOID,
+  "linear": Activations.LINEAR
 };
 
 /** A map between names and regularization functions. */
@@ -141,7 +142,7 @@ export class State {
   discretize = false;
   tutorial: string = null;
   percTrainData = 50;
-  activation = nn.Activations.RELU;
+  activation = Activations.RELU;
   regularization: nn.RegularizationFunction = null;
   problem = Problem.CLASSIFICATION;
   initZero = false;


### PR DESCRIPTION
From Google Jules:

- Added `node.range` field of type `range.Range` to the `Node` class.
- Moved `ActivationFunction` interface and `Activations` class to `src/activation.ts` to avoid import cycles.
- Updated imports and references in `src/nn.ts`, `src/range.ts`, `src/playground.ts`, and `src/state.ts`.
- Marked the TODO item for adding `node.range` as done.
- Added AGENTS.md with notes about branch naming and package-lock.json.