### PR TITLE
Allow custom input ranges in updateNodeRanges

### DIFF
--- a/TODO
+++ b/TODO
@@ -28,7 +28,7 @@
         node.range = activationRange(state.activationFunction, range);
 
 
-[ ] give updateNodeRanges a Map from input name (e.g. "bit4") to Range, and use
+[x] give updateNodeRanges a Map from input name (e.g. "bit4") to Range, and use
     that range instead of (0.0, 1.0) for the input nodes which have the specified name.
 
 [ ] every time the weights are updated (either by the user, by reset(), or by backprop),

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -359,14 +359,16 @@ export function getOutputNode(network: Node[][]) {
  *
  * @param network The neural network.
  * @param activationFunction The activation function used in the network.
+ * @param inputRanges A map from input node id to its range.
  */
 export function updateNodeRanges(network: Node[][],
-    activationFunction: ActivationFunction): void {
+    activationFunction: ActivationFunction,
+    inputRanges: Map<string, Range>): void {
   // Set the initial ranges in the input layer.
   let inputLayer = network[0];
   for (let i = 0; i < inputLayer.length; i++) {
     let node = inputLayer[i];
-    node.range = [0.0, 1.0];
+    node.range = inputRanges.get(node.id) || [0.0, 1.0];
   }
 
   // Propagate the ranges for hidden and output layers.


### PR DESCRIPTION
from Google Jules: 

Give updateNodeRanges a Map from input name (e.g. "bit4") to Range, and use that range instead of (0.0, 1.0) for the input nodes which have the specified name.

Also marks the corresponding TODO as completed.