### PR TITLE
Call updateNodeRanges on weight changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,14 @@
       },
       "devDependencies": {
         "@types/d3": "^3.5.53",
+        "browserify": "^17.0.1",
         "concat": "^1.0.3",
         "concurrently": "3.1.0",
-        "copyfiles": "1.0.0",
+        "copyfiles": "^1.0.0",
         "rimraf": "2.5.4",
         "serve": "^11.3.0",
         "terser": "^5.43.1",
-        "tsify": "^4.0.0",
+        "tsify": "^4.0.2",
         "typescript": "^2.9.2",
         "uglify-js": "^2.8.29",
         "watchify": "^4.0.0"
@@ -459,10 +460,11 @@
       }
     },
     "node_modules/browserify": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
-      "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.1.tgz",
+      "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -480,7 +482,7 @@
         "duplexer2": "~0.1.2",
         "events": "^3.0.0",
         "glob": "^7.1.0",
-        "has": "^1.0.0",
+        "hasown": "^2.0.0",
         "htmlescape": "^1.1.0",
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
@@ -837,8 +839,9 @@
     "node_modules/concat": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/concat/-/concat-1.0.3.tgz",
-      "integrity": "sha1-QPM1MInWVGdpXLGIa0Xt1jfYzKg=",
+      "integrity": "sha512-f/ZaH1aLe64qHgTILdldbvyfGiGF4uzeo9IuXUloIOLQzFmIPloy9QbZadNsuVv0j5qbKQvQb/H/UYf2UsKTpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^2.9.0"
       },
@@ -929,8 +932,9 @@
     "node_modules/copyfiles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.0.0.tgz",
-      "integrity": "sha1-MXAmhx1TkOMqzQPsRYd1Jn6UvCo=",
+      "integrity": "sha512-qWZtHkavMR6hkq6bpJVrPcXPKcPAsQFsXd9LnFV8yjhJbSb/oN7WAJ6lSiWkaPw1naiWY6l7tTkMzDq7Na6p+g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.0.5",
         "ltcdr": "^2.2.1",
@@ -1349,10 +1353,14 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
@@ -1523,6 +1531,19 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hmac-drbg": {
@@ -3286,6 +3307,7 @@
       "resolved": "https://registry.npmjs.org/tsify/-/tsify-4.0.2.tgz",
       "integrity": "sha512-XZ4jziRS8SBnoSnp1QOtASxjqhvOSfXhO8cD5WPBpXD6UKDCMQ/n7L1cr+Wlb5htIZJuvfhfxely+HODsVRWLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "convert-source-map": "^1.1.0",
         "fs.realpath": "^1.0.0",
@@ -3983,9 +4005,9 @@
       }
     },
     "browserify": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
-      "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.1.tgz",
+      "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
       "dev": true,
       "requires": {
         "assert": "^1.4.0",
@@ -4004,7 +4026,7 @@
         "duplexer2": "~0.1.2",
         "events": "^3.0.0",
         "glob": "^7.1.0",
-        "has": "^1.0.0",
+        "hasown": "^2.0.0",
         "htmlescape": "^1.1.0",
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
@@ -4324,7 +4346,7 @@
     "concat": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/concat/-/concat-1.0.3.tgz",
-      "integrity": "sha1-QPM1MInWVGdpXLGIa0Xt1jfYzKg=",
+      "integrity": "sha512-f/ZaH1aLe64qHgTILdldbvyfGiGF4uzeo9IuXUloIOLQzFmIPloy9QbZadNsuVv0j5qbKQvQb/H/UYf2UsKTpw==",
       "dev": true,
       "requires": {
         "commander": "^2.9.0"
@@ -4399,7 +4421,7 @@
     "copyfiles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.0.0.tgz",
-      "integrity": "sha1-MXAmhx1TkOMqzQPsRYd1Jn6UvCo=",
+      "integrity": "sha512-qWZtHkavMR6hkq6bpJVrPcXPKcPAsQFsXd9LnFV8yjhJbSb/oN7WAJ6lSiWkaPw1naiWY6l7tTkMzDq7Na6p+g==",
       "dev": true,
       "requires": {
         "glob": "^7.0.5",
@@ -4765,9 +4787,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "get-assigned-identifiers": {
@@ -4893,6 +4915,15 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
   },
   "devDependencies": {
     "@types/d3": "^3.5.53",
+    "browserify": "^17.0.1",
     "concat": "^1.0.3",
     "concurrently": "3.1.0",
-    "copyfiles": "1.0.0",
+    "copyfiles": "^1.0.0",
     "rimraf": "2.5.4",
     "serve": "^11.3.0",
     "terser": "^5.43.1",
-    "tsify": "^4.0.0",
+    "tsify": "^4.0.2",
     "typescript": "^2.9.2",
     "uglify-js": "^2.8.29",
     "watchify": "^4.0.0"

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ActivationFunction} from "./activation";
-import {Range, addRange, multiplyRange, activationRange} from "./range";
+import {Range, addRange, multiplyRange, activationRange, BIT_RANGES} from "./range";
 
 /**
  * A node in a neural network. Each node has a state
@@ -293,7 +293,7 @@ export function backProp(network: Node[][], target: number,
  * derivatives.
  */
 export function updateWeights(network: Node[][], learningRate: number,
-    regularizationRate: number) {
+    regularizationRate: number, activationFunction: ActivationFunction) {
   for (let layerIdx = 1; layerIdx < network.length; layerIdx++) {
     let currentLayer = network[layerIdx];
     for (let i = 0; i < currentLayer.length; i++) {
@@ -333,6 +333,7 @@ export function updateWeights(network: Node[][], learningRate: number,
       }
     }
   }
+  updateNodeRanges(network, activationFunction, BIT_RANGES);
 }
 
 /** Iterates over every node in the network/ */

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import * as nn from "./nn";
 import { ActivationFunction, Activations } from "./activation";
+import { BIT_RANGES } from "./range";
 import {HeatMap, reduceMatrix} from "./heatmap";
 import {
   State,
@@ -842,6 +843,7 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
         } else {
           (nodeOrLink as nn.Node).bias = +this.value;
         }
+        nn.updateNodeRanges(network, state.activation, BIT_RANGES);
         updateUI();
       }
     });
@@ -1055,7 +1057,7 @@ function oneStep(): void {
     nn.forwardProp(network, input);
     nn.backProp(network, point.label, nn.Errors.SQUARE);
     if ((i + 1) % state.batchSize === 0) {
-      nn.updateWeights(network, state.learningRate, state.regularizationRate);
+      nn.updateWeights(network, state.learningRate, state.regularizationRate, state.activation);
     }
   });
   // Compute the loss.
@@ -1151,6 +1153,8 @@ function reset(onStartup=false, hardcodeWeights=false) {
 
   lossTrain = getLoss(network, trainData);
   lossTest = getLoss(network, testData);
+  // Update node ranges after network initialization or weight hardcoding
+  nn.updateNodeRanges(network, state.activation, BIT_RANGES);
   drawNetwork(network);
   updateUI(true);
 }

--- a/src/range.ts
+++ b/src/range.ts
@@ -62,3 +62,14 @@ export function activationRange(
     return range;
   }
 }
+
+/**
+ * Input ranges for bits 4 through 7, setting them to [1.0, 1.0].
+ * Other bits default to [0.0, 1.0] in updateNodeRanges.
+ */
+export const BIT_RANGES: Map<string, Range> = new Map([
+  ["bit4", [1.0, 1.0] as Range],
+  ["bit5", [1.0, 1.0] as Range],
+  ["bit6", [1.0, 1.0] as Range],
+  ["bit7", [1.0, 1.0] as Range],
+]);


### PR DESCRIPTION
From Google Jules:

Call updateNodeRanges every time weights are updated:
- User manual adjustment via hovercard
- After reset()
- After backprop updates

This ensures that the node range analysis, particularly for inputs `bit4` through `bit7` (which are now set to a fixed range of [1.0, 1.0]), is consistently applied and reflected in the UI.

Also installed missing dev dependencies and fixed a TypeScript typing issue in the BIT_RANGES constant.