### PR TITLE
Render ranges in CODE section

### DIFF
--- a/TODO
+++ b/TODO
@@ -33,7 +33,7 @@
 
 [x] every time the weights are updated (either by the user, by reset(), or by backprop),
     call updateNodeRange() with a Map which sets `bit4` through `bit7` to (1.0, 1.0).
-[ ] in the function which calculates the text of the CODE section, render the range of
+[x] in the function which calculates the text of the CODE section, render the range of
     every input and every definition:
     
     bit0 ∈ [0.0, 1.0]

--- a/TODO
+++ b/TODO
@@ -81,3 +81,9 @@
     or
 
     x00 = bit7 + bit6 + bit5 + bit4 + bit3 + bit2 + bit1 + bit0
+
+[ ] if out's range is not [0.0, 0.0], draw a red rectangle around the "out =
+    ..." formula and around the OUTPUT's top row of bits.
+[ ] either add the word "safe", in green, or the word "unsafe", in red, above
+    the red rectangle. make it big and bold and with a black outline around the
+    letters.


### PR DESCRIPTION
From Google Jules:

Display the range of every input and definition in the CODE section.

Example:
bit0 ∈ [0.0, 1.0]

x00 ∈ [4.0, 8.0]
x00 = relu(bit7 + bit6 + bit5 + bit4 + bit3 + bit2 + bit1 + bit0)