### PR TITLE
Refactor: Consolidate seed controls and update top bar UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,9 +124,9 @@ limitations under the License.
         </div>
       </div>
       <div class="control ui-seed-input">
-        <label for="userSeed">Seed</label>
+        <label for="userSeed" id="seedLabel">Seed</label>
         <div style="display: flex; align-items: center;">
-          <input type="text" id="userSeed" class="ui-input" style="width: 100px; margin-right: 5px;">
+          <input type="text" id="userSeed" class="ui-input" style="width: 100px; margin-right: 5px;" placeholder="Enter seed">
           <button id="applyUserSeed" class="mdl-button mdl-js-button mdl-button--raised" title="Apply new seed">
             Set
           </button>

--- a/index.html
+++ b/index.html
@@ -123,23 +123,10 @@ limitations under the License.
           </select>
         </div>
       </div>
-      <div class="control ui-problem">
-        <label for="problem">Problem type</label>
-        <div class="select">
-          <select id="problem">
-            <option value="classification">Classification</option>
-            <option value="regression">Regression</option>
-          </select>
-        </div>
-      </div>
-      <div class="control ui-seed-display">
-        <label for="currentSeed">Current seed</label>
-        <span class="value" id="currentSeedValue"></span>
-      </div>
       <div class="control ui-seed-input">
-        <label for="userSeed">Set new seed</label>
+        <label for="userSeed">Seed</label>
         <div style="display: flex; align-items: center;">
-          <input type="text" id="userSeed" class="ui-input" style="width: 70px; margin-right: 5px;">
+          <input type="text" id="userSeed" class="ui-input" style="width: 100px; margin-right: 5px;">
           <button id="applyUserSeed" class="mdl-button mdl-js-button mdl-button--raised" title="Apply new seed">
             Set
           </button>

--- a/index.html
+++ b/index.html
@@ -124,9 +124,9 @@ limitations under the License.
         </div>
       </div>
       <div class="control ui-seed-input">
-        <label for="userSeed" id="seedLabel">Seed</label>
+        <label for="userSeed">Seed</label>
         <div style="display: flex; align-items: center;">
-          <input type="text" id="userSeed" class="ui-input" style="width: 100px; margin-right: 5px;" placeholder="Enter seed">
+          <input type="text" id="userSeed" class="ui-input" style="width: 70px; margin-right: 5px;">
           <button id="applyUserSeed" class="mdl-button mdl-js-button mdl-button--raised" title="Apply new seed">
             Set
           </button>

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -557,9 +557,14 @@ function makeGUI() {
 }
 
 function updateSeedDisplay() {
+  const seedLabel = document.getElementById("seedLabel");
+  if (seedLabel) {
+    seedLabel.innerText = `Seed ${state.seed}`;
+  }
+  // Clear the input field after updating the label
   const userSeedInput = document.getElementById("userSeed") as HTMLInputElement;
   if (userSeedInput) {
-    userSeedInput.value = state.seed;
+    userSeedInput.value = ""; // Clear previous input
   }
 }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -557,14 +557,9 @@ function makeGUI() {
 }
 
 function updateSeedDisplay() {
-  const seedLabel = document.getElementById("seedLabel");
-  if (seedLabel) {
-    seedLabel.innerText = `Seed ${state.seed}`;
-  }
-  // Clear the input field after updating the label
   const userSeedInput = document.getElementById("userSeed") as HTMLInputElement;
   if (userSeedInput) {
-    userSeedInput.value = ""; // Clear previous input
+    userSeedInput.value = state.seed;
   }
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -82,16 +82,6 @@ export enum Type {
   OBJECT
 }
 
-export enum Problem {
-  CLASSIFICATION,
-  REGRESSION
-}
-
-export let problems = {
-  "classification": Problem.CLASSIFICATION,
-  "regression": Problem.REGRESSION
-};
-
 export interface Property {
   name: string;
   type: Type;
@@ -126,7 +116,6 @@ export class State {
     {name: "bit7", type: Type.BOOLEAN},
     {name: "collectStats", type: Type.BOOLEAN},
     {name: "tutorial", type: Type.STRING},
-    {name: "problem", type: Type.OBJECT, keyMap: problems},
     {name: "initZero", type: Type.BOOLEAN},
     {name: "hideText", type: Type.BOOLEAN},
     {name: "dataCollapsed", type: Type.BOOLEAN},
@@ -135,7 +124,7 @@ export class State {
   ];
 
   [key: string]: any;
-  learningRate = 0.03;
+  learningRate = 0.01;
   regularizationRate = 0;
   numBits = 8;
   batchSize = 10;
@@ -144,7 +133,6 @@ export class State {
   percTrainData = 50;
   activation = Activations.RELU;
   regularization: nn.RegularizationFunction = null;
-  problem = Problem.CLASSIFICATION;
   initZero = false;
   hideText = false;
   collectStats = false;

--- a/styles.css
+++ b/styles.css
@@ -332,6 +332,13 @@ header h1 .optional {
   border-bottom: solid 1px #ccc;
   color: #333;
   outline: none;
+  background-color: white; /* Ensure input background matches */
+  padding: 6px 0px; /* Match select padding */
+  border-bottom: solid 1px #ccc; /* Match select border */
+}
+
+#top-controls .control input.ui-input:focus {
+  border-bottom-color: #183D4E; /* Match select focus border */
 }
 
 #top-controls .control select:focus {

--- a/styles.css
+++ b/styles.css
@@ -341,6 +341,22 @@ header h1 .optional {
   border-bottom-color: #183D4E; /* Match select focus border */
 }
 
+/* Ensure seed input control group has enough space and aligns items */
+#top-controls .control.ui-seed-input {
+  max-width: 280px; /* Increased max-width for the seed control */
+  min-width: 220px; /* Adjusted min-width */
+}
+
+#top-controls .control.ui-seed-input > div { /* The div containing input and button */
+  display: flex;
+  align-items: center;
+}
+
+#top-controls .control.ui-seed-input input.ui-input {
+  flex-grow: 1; /* Allow input to take available space */
+  width: auto; /* Override fixed width from inline style if necessary */
+}
+
 #top-controls .control select:focus {
   border-bottom-color: #183D4E;
 }

--- a/styles.css
+++ b/styles.css
@@ -343,8 +343,8 @@ header h1 .optional {
 
 /* Ensure seed input control group has enough space and aligns items */
 #top-controls .control.ui-seed-input {
-  max-width: 280px; /* Increased max-width for the seed control */
-  min-width: 220px; /* Adjusted min-width */
+  max-width: 200px; /* Adjusted max-width for the seed control */
+  min-width: 150px; /* Adjusted min-width */
 }
 
 #top-controls .control.ui-seed-input > div { /* The div containing input and button */
@@ -352,10 +352,7 @@ header h1 .optional {
   align-items: center;
 }
 
-#top-controls .control.ui-seed-input input.ui-input {
-  flex-grow: 1; /* Allow input to take available space */
-  width: auto; /* Override fixed width from inline style if necessary */
-}
+/* Input width is now controlled by inline style in HTML (e.g., 70px) */
 
 #top-controls .control select:focus {
   border-bottom-color: #183D4E;

--- a/styles.css
+++ b/styles.css
@@ -257,8 +257,9 @@ header h1 .optional {
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
-  -webkit-justify-content: space-betweenspace-between;
+  -webkit-justify-content: space-between; /* Corrected typo */
   justify-content: space-between;
+  align-items: center; /* Align items vertically centered in the bar */
 }
 
 #top-controls .timeline-controls {
@@ -270,6 +271,7 @@ header h1 .optional {
   align-items: center;
   margin-right: 20px;
   width: 140px;
+  flex-shrink: 0; /* Prevent timeline controls from shrinking */
 }
 
 #play-pause-button .material-icons {
@@ -292,11 +294,17 @@ header h1 .optional {
 }
 
 #top-controls .control {
-  flex-grow: 1;
-  max-width: 180px;
-  min-width: 110px;
-  margin-left: 30px;
+  flex-grow: 1; /* Allow controls to grow and fill space */
+  /* max-width: 180px; Removed this, was too restrictive */
+  min-width: 0; /* Allow controls to shrink to their content's min-width */
+  margin-left: 15px; /* Reduced margin */
   margin-top: 6px;
+  display: flex;
+  flex-direction: column; /* Stack label on top of input/select */
+}
+
+#top-controls .control:first-of-type {
+    margin-left: 0; /* The timeline-controls have margin-right, so first actual control can be 0 */
 }
 
 #top-controls .control .label,
@@ -343,13 +351,23 @@ header h1 .optional {
 
 /* Ensure seed input control group has enough space and aligns items */
 #top-controls .control.ui-seed-input {
-  max-width: 200px; /* Adjusted max-width for the seed control */
-  min-width: 150px; /* Adjusted min-width */
+  flex-grow: 0; /* Do not allow this to grow, take content width */
+  flex-shrink: 0; /* Do not allow this to shrink */
+  /* min-width and max-width removed, should be sized by content */
+  margin-left: 15px; /* Consistent margin */
 }
 
 #top-controls .control.ui-seed-input > div { /* The div containing input and button */
   display: flex;
   align-items: center;
+}
+
+#top-controls .control.ui-seed-input button#applyUserSeed {
+    min-width: 40px; /* Give button a specific min-width if 'Set' is too small */
+    padding: 0 8px; /* Adjust padding */
+    height: 30px; /* Align height with input fields */
+    line-height: 30px; /* Center text in button */
+    margin-left: 5px; /* Keep the margin from inline style */
 }
 
 /* Input width is now controlled by inline style in HTML (e.g., 70px) */


### PR DESCRIPTION
From Google Jules:

- Set default learning rate to 0.01.
- Remove 'Problem type' dropdown from the top bar and associated logic.
- Move seed controls (current seed display and set seed input) into the top bar.
- Combine current seed display and set seed input into a single widget:
    - Label is 'Seed'.
    - Input field displays the current seed and allows editing.
    - 'Set' button applies the seed from the input.
- Adjust CSS for the new seed widget to align with top bar styling.