### PR TITLE
Change input bit features from 0/1 to -1/1

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -22,7 +22,7 @@ export type Example2D = {
   x: number,
   y: number,
   label: number,
-  bits?: boolean[]
+  bits?: number[]
 };
 
 type Point = {
@@ -151,40 +151,42 @@ export function uncenterize(x: number, y: number):
     (y / (desiredWidth * 2) + 0.5) * naturalWidth
   ];
 }
-export function bitsToXY(bits: boolean[]):
+export function bitsToXY(bits: number[]):
     [number, number] {
   let x = 0;
   let y = 0;
+  // Convert -1/1 bits to 0/1 for calculation
   bits.forEach((bit, i) => {
+    let val = (bit + 1) / 2; // Map -1 to 0, 1 to 1
     if (i >= 4) {
-      x = x * 2 + (bit ? 1 : 0);
+      x = x * 2 + val;
     } else {
-      y = y * 2 + (bit ? 1 : 0);
+      y = y * 2 + val;
     }
   });
   return centerize(x, y);
 }
 export function xyToBits(centeredX: number, centeredY: number):
-    boolean[] {
+    number[] {
   let [x, y] = uncenterize(centeredX, centeredY);
-  let bits = [];
+  let bits: number[] = [];
   for (let i = bitlength; i-->0;) {
     if (i >= 4) {
       let leastSignificantBit = Math.round(x) % 2;
-      bits[i] = leastSignificantBit === 1;
+      bits[i] = leastSignificantBit === 1 ? 1 : -1;
       x = (x - leastSignificantBit) / 2;
     } else {
       let leastSignificantBit = Math.round(y) % 2;
-      bits[i] = leastSignificantBit === 1;
+      bits[i] = leastSignificantBit === 1 ? 1 : -1;
       y = (y - leastSignificantBit) / 2;
     }
   }
   return bits;
 }
-export function wordToBits(word: number): boolean[] {
-  let bits = [];
+export function wordToBits(word: number): number[] {
+  let bits: number[] = [];
   for (let i = bitlength; i-->0;) {
-    bits[i] = word % 2 === 1;
+    bits[i] = (word % 2 === 1) ? 1 : -1;
     word = (word - word % 2) / 2;
   }
   return bits;
@@ -193,19 +195,26 @@ export function classifyParityData(numSamples: number, noise: number):
     Example2D[] {
   let points: Example2D[] = [];
 
-  function parity(bits: boolean[]):
+  // Parity function now expects bits as -1 or 1
+  function parity(bits: number[]):
       boolean {
-    let parity = false;
-    bits.forEach((bit) => parity = parity !== bit);
-    return parity;
+    // Convert to 0/1 for parity calculation: (val + 1) / 2 maps -1 to 0, 1 to 1
+    let p = false;
+    bits.forEach((bit) => p = p !== ((bit + 1) / 2 === 1));
+    return p; // Return the calculated parity 'p'
   }
 
   for (let i = 0; i < numSamples; i++) {
     let bits = wordToBits(i);
     let [x,y] = bitsToXY(bits);
     let label: number;
-    // If bits 4, 5, 6, and 7 are all 1, the expected result is 0 (even parity, -1).
-    if (bits[0] && bits[1] && bits[2] && bits[3]) {
+    // If bits 0, 1, 2, and 3 (representing y value) are all 1 (i.e., number 1),
+    // the expected result is -1 (even parity for these 4 bits).
+    // Note: Original comment referred to bits 4,5,6,7.
+    // bits[0] to bits[3] are for y, bits[4] to bits[7] are for x.
+    // Assuming the special condition is for the "y" component bits.
+    // (1+1)/2 = 1. So bits[0] === 1 checks for the bit being 1.
+    if (bits[0] === 1 && bits[1] === 1 && bits[2] === 1 && bits[3] === 1) {
       label = -1;
     } else {
       label = parity(bits) ? 1 : -1;

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -179,10 +179,11 @@ export class HeatMap {
     context.putImageData(image, 0, 0);
   }
 
-  private bitCount(bits: boolean[]): number {
+  private bitCount(bits: number[]): number {
     let count = 0;
     for (let i = 0; i < bits.length; i++) {
-      if (bits[i]) {
+      // Count number of bits that are 1 (originally true)
+      if (bits[i] === 1) {
         count++;
       }
     }
@@ -226,7 +227,8 @@ export class HeatMap {
       .style("fill", "white")
       .text((d: Example2D) => {
         if (!d.bits) return "";
-        let firstHalf = d.bits.slice(0, 4).map(b => b ? "1" : "0").join("");
+        // Display 1 for 1, and 0 for -1 (to match original display)
+        let firstHalf = d.bits.slice(0, 4).map(b => (b === 1 ? "1" : "0")).join("");
         return firstHalf;
       });
     pointGroups.append("text")
@@ -237,7 +239,8 @@ export class HeatMap {
       .style("fill", "white")
       .text((d: Example2D) => {
         if (!d.bits) return "";
-        let secondHalf = d.bits.slice(4).map(b => b ? "1" : "0").join("");
+        // Display 1 for 1, and 0 for -1 (to match original display)
+        let secondHalf = d.bits.slice(4).map(b => (b === 1 ? "1" : "0")).join("");
         return secondHalf;
       });
     pointGroups.append("text")

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -369,7 +369,7 @@ export function updateNodeRanges(network: Node[][],
   let inputLayer = network[0];
   for (let i = 0; i < inputLayer.length; i++) {
     let node = inputLayer[i];
-    node.range = inputRanges.get(node.id) || [0.0, 1.0];
+    node.range = inputRanges.get(node.id) || [-1.0, 1.0];
   }
 
   // Propagate the ranges for hidden and output layers.

--- a/src/range.ts
+++ b/src/range.ts
@@ -64,12 +64,15 @@ export function activationRange(
 }
 
 /**
- * Input ranges for bits 4 through 7, setting them to [1.0, 1.0].
- * Other bits default to [0.0, 1.0] in updateNodeRanges.
+ * Input ranges for bits 0 through 7, setting them to [-1.0, 1.0].
  */
 export const BIT_RANGES: Map<string, Range> = new Map([
-  ["bit4", [1.0, 1.0] as Range],
-  ["bit5", [1.0, 1.0] as Range],
-  ["bit6", [1.0, 1.0] as Range],
-  ["bit7", [1.0, 1.0] as Range],
+  ["bit0", [-1.0, 1.0] as Range],
+  ["bit1", [-1.0, 1.0] as Range],
+  ["bit2", [-1.0, 1.0] as Range],
+  ["bit3", [-1.0, 1.0] as Range],
+  ["bit4", [-1.0, 1.0] as Range],
+  ["bit5", [-1.0, 1.0] as Range],
+  ["bit6", [-1.0, 1.0] as Range],
+  ["bit7", [-1.0, 1.0] as Range],
 ]);

--- a/src/state.ts
+++ b/src/state.ts
@@ -106,14 +106,14 @@ export class State {
     {name: "percTrainData", type: Type.NUMBER},
     {name: "x", type: Type.BOOLEAN},
     {name: "y", type: Type.BOOLEAN},
-    {name: "bit0", type: Type.BOOLEAN},
-    {name: "bit1", type: Type.BOOLEAN},
-    {name: "bit2", type: Type.BOOLEAN},
-    {name: "bit3", type: Type.BOOLEAN},
-    {name: "bit4", type: Type.BOOLEAN},
-    {name: "bit5", type: Type.BOOLEAN},
-    {name: "bit6", type: Type.BOOLEAN},
-    {name: "bit7", type: Type.BOOLEAN},
+    {name: "bit0", type: Type.NUMBER},
+    {name: "bit1", type: Type.NUMBER},
+    {name: "bit2", type: Type.NUMBER},
+    {name: "bit3", type: Type.NUMBER},
+    {name: "bit4", type: Type.NUMBER},
+    {name: "bit5", type: Type.NUMBER},
+    {name: "bit6", type: Type.NUMBER},
+    {name: "bit7", type: Type.NUMBER},
     {name: "collectStats", type: Type.BOOLEAN},
     {name: "tutorial", type: Type.STRING},
     {name: "initZero", type: Type.BOOLEAN},
@@ -141,14 +141,14 @@ export class State {
   networkShape: number[] = [8, 8];
   x = false;
   y = false;
-  bit0 = true;
-  bit1 = true;
-  bit2 = true;
-  bit3 = true;
-  bit4 = true;
-  bit5 = true;
-  bit6 = true;
-  bit7 = true;
+  bit0 = 1;
+  bit1 = 1;
+  bit2 = 1;
+  bit3 = 1;
+  bit4 = 1;
+  bit5 = 1;
+  bit6 = 1;
+  bit7 = 1;
   dataset: dataset.DataGenerator = dataset.classifyParityData;
   regDataset: dataset.DataGenerator = dataset.regressPlane;
   seed: string;


### PR DESCRIPTION
From Google Jules:

- Modified `dataset.ts` to generate bit features as -1 or 1 instead of boolean.
- Updated `bitsToXY` and `xyToBits` to handle the new number-based bits.
- Adjusted `classifyParityData` for the new bit representation.
- Changed `BIT_RANGES` in `range.ts` to `[-1.0, 1.0]` for all bits.
- Updated the default fallback range in `nn.ts`'s `updateNodeRanges`.
- Modified `state.ts` to change bit types from Boolean to Number and default values from true to 1.
- Fixed type errors in `heatmap.ts` to correctly display number-based bits and count.