### PR TITLE
Update playground UI based on user request

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,8 +249,8 @@ limitations under the License.
             </div>
             <div id="linechart"></div>
           </div>
-          <div id="heatmap"></div>
           <div id="practice-safety-container" style="position: relative; height: 30px; margin-bottom: 10px;"></div>
+          <div id="heatmap"></div>
           <div style="float:left;margin-left:10px">
             <div style="display:flex; align-items:center;">
 

--- a/index.html
+++ b/index.html
@@ -96,33 +96,6 @@ limitations under the License.
           </select>
         </div>
       </div>
-      <div class="control ui-regularization">
-        <label for="regularizations">Regularization</label>
-        <div class="select">
-          <select id="regularizations">
-            <option value="none">None</option>
-            <option value="L1">L1</option>
-            <option value="L2">L2</option>
-          </select>
-        </div>
-      </div>
-      <div class="control ui-regularizationRate">
-        <label for="regularRate">Regularization rate</label>
-        <div class="select">
-          <select id="regularRate">
-            <option value="0">0</option>
-            <option value="0.001">0.001</option>
-            <option value="0.003">0.003</option>
-            <option value="0.01">0.01</option>
-            <option value="0.03">0.03</option>
-            <option value="0.1">0.1</option>
-            <option value="0.3">0.3</option>
-            <option value="1">1</option>
-            <option value="3">3</option>
-            <option value="10">10</option>
-          </select>
-        </div>
-      </div>
       <div class="control ui-seed-input">
         <label for="userSeed">Seed</label>
         <div style="display: flex; align-items: center;">
@@ -270,10 +243,6 @@ limitations under the License.
       <div class="content-wrapper">
         <div class="section-content">
           <div class="metrics">
-            <div class="output-stats ui-percTrainData">
-              <span>Test loss</span>
-              <div class="value" id="loss-test"></div>
-            </div>
             <div class="output-stats train">
               <span>Training loss</span>
               <div class="value" id="loss-train"></div>
@@ -281,6 +250,7 @@ limitations under the License.
             <div id="linechart"></div>
           </div>
           <div id="heatmap"></div>
+          <div id="practice-safety-container" style="position: relative; height: 30px; margin-bottom: 10px;"></div>
           <div style="float:left;margin-left:10px">
             <div style="display:flex; align-items:center;">
 

--- a/src/linechart.ts
+++ b/src/linechart.ts
@@ -17,28 +17,29 @@ import * as d3 from 'd3';
 
 type DataPoint = {
   x: number;
-  y: number[];
+  y: number; // Changed from y: number[] to y: number
 };
 
 /**
- * A multi-series line chart that allows you to append new data points
+ * A single-series line chart that allows you to append new data points
  * as data becomes available.
  */
 export class AppendingLineChart {
-  private numLines: number;
   private data: DataPoint[] = [];
   private svg;
   private xScale;
   private yScale;
-  private paths;
-  private lineColors: string[];
+  private path; // Changed from paths to path
+  private lineColor: string; // Changed from lineColors to lineColor
 
   private minY = Number.MAX_VALUE;
   private maxY = Number.MIN_VALUE;
 
   constructor(container, lineColors: string[]) {
-    this.lineColors = lineColors;
-    this.numLines = lineColors.length;
+    if (lineColors.length !== 1) {
+      throw new Error("AppendingLineChart now expects exactly one color for a single line.");
+    }
+    this.lineColor = lineColors[0];
     let node = container.node() as HTMLElement;
     let totalWidth = node.offsetWidth;
     let totalHeight = node.offsetHeight;
@@ -60,16 +61,13 @@ export class AppendingLineChart {
       .append("g")
         .attr("transform", `translate(${margin.left},${margin.top})`);
 
-    this.paths = new Array(this.numLines);
-    for (let i = 0; i < this.numLines; i++) {
-      this.paths[i] = this.svg.append("path")
-        .attr("class", "line")
-        .style({
-          "fill": "none",
-          "stroke": lineColors[i],
-          "stroke-width": "1.5px"
-        });
-    }
+    this.path = this.svg.append("path") // Only one path
+      .attr("class", "line")
+      .style({
+        "fill": "none",
+        "stroke": this.lineColor, // Use the single color
+        "stroke-width": "1.5px"
+      });
   }
 
   reset() {
@@ -79,16 +77,15 @@ export class AppendingLineChart {
     this.maxY = Number.MIN_VALUE;
   }
 
-  addDataPoint(dataPoint: number[]) {
-    if (dataPoint.length !== this.numLines) {
-      throw Error("Length of dataPoint must equal number of lines");
+  addDataPoint(dataPoint: number[]) { // dataPoint is now [lossTrain]
+    if (dataPoint.length !== 1) {
+      throw Error("addDataPoint now expects an array with a single number for the training loss.");
     }
-    dataPoint.forEach(y => {
-      this.minY = Math.min(this.minY, y);
-      this.maxY = Math.max(this.maxY, y);
-    });
+    const yVal = dataPoint[0];
+    this.minY = Math.min(this.minY, yVal);
+    this.maxY = Math.max(this.maxY, yVal);
 
-    this.data.push({x: this.data.length + 1, y: dataPoint});
+    this.data.push({x: this.data.length + 1, y: yVal}); // Store yVal directly
     this.redraw();
   }
 
@@ -96,14 +93,12 @@ export class AppendingLineChart {
     // Adjust the x and y domain.
     this.xScale.domain([1, this.data.length]);
     this.yScale.domain([this.minY, this.maxY]);
-    // Adjust all the <path> elements (lines).
-    let getPathMap = (lineIndex: number) => {
-      return d3.svg.line<{x: number, y:number}>()
+
+    // Adjust the <path> element.
+    const line = d3.svg.line<DataPoint>()
       .x(d => this.xScale(d.x))
-      .y(d => this.yScale(d.y[lineIndex]));
-    };
-    for (let i = 0; i < this.numLines; i++) {
-      this.paths[i].datum(this.data).attr("d", getPathMap(i));
-    }
+      .y(d => this.yScale(d.y)); // d.y is now a number
+
+    this.path.datum(this.data).attr("d", line);
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -28,12 +28,7 @@ export let activations: {[key: string]: ActivationFunction} = {
   "linear": Activations.LINEAR
 };
 
-/** A map between names and regularization functions. */
-export let regularizations: {[key: string]: nn.RegularizationFunction} = {
-  "none": null,
-  "L1": nn.RegularizationFunction.L1,
-  "L2": nn.RegularizationFunction.L2
-};
+// Removed regularizations map
 
 /** A map between dataset names and functions that generate classification data. */
 export let datasets: {[key: string]: dataset.DataGenerator} = {
@@ -93,13 +88,13 @@ export class State {
 
   private static PROPS: Property[] = [
     {name: "activation", type: Type.OBJECT, keyMap: activations},
-    {name: "regularization", type: Type.OBJECT, keyMap: regularizations},
+    // {name: "regularization", type: Type.OBJECT, keyMap: regularizations}, // Removed
     {name: "numBits", type: Type.NUMBER},
     {name: "batchSize", type: Type.NUMBER},
     {name: "dataset", type: Type.OBJECT, keyMap: datasets},
     {name: "regDataset", type: Type.OBJECT, keyMap: regDatasets},
     {name: "learningRate", type: Type.NUMBER},
-    {name: "regularizationRate", type: Type.NUMBER},
+    // {name: "regularizationRate", type: Type.NUMBER}, // Removed
     {name: "networkShape", type: Type.ARRAY_NUMBER},
     {name: "seed", type: Type.STRING},
     {name: "discretize", type: Type.BOOLEAN},
@@ -126,14 +121,14 @@ export class State {
 
   [key: string]: any;
   learningRate = 0.3;
-  regularizationRate = 0;
+  // regularizationRate = 0; // Removed
   numBits = 8;
   batchSize = 10;
   discretize = false;
   tutorial: string = null;
   percTrainData = 50;
   activation = Activations.RELU;
-  regularization: nn.RegularizationFunction = null;
+  // regularization: nn.RegularizationFunction = null; // Removed
   initZero = false;
   hideText = false;
   collectStats = false;

--- a/styles.css
+++ b/styles.css
@@ -1219,11 +1219,12 @@ footer .logo {
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: #eee; /* Grey background like theory box container */
 }
 
 #practice-safety-text {
   color: green; /* Default to safe */
-  background-color: rgba(255, 255, 255, 0.8);
+  /* background-color: rgba(255, 255, 255, 0.8); Removed */
   font-size: 13px;
   text-align: center;
   white-space: nowrap;

--- a/styles.css
+++ b/styles.css
@@ -1194,8 +1194,37 @@ footer .logo {
   transform: rotate(-90deg);
 }
 
-.lr-changed-highlight {
-  background-color: #fffde7; /* A very light yellow, less intrusive */
+.lr-input-highlight {
+  background-color: #fffde7 !important; /* A very light yellow, less intrusive */
   border-radius: 4px; /* Optional: if you want rounded corners for the highlight */
-  transition: background-color 0.3s ease-out;
+  transition: background-color 0.3s ease-out !important;
+}
+
+#practice-safety-container {
+  /* Ensure this container allows absolute positioning of its children */
+  position: relative;
+  height: 30px; /* Adjust as needed based on content */
+  margin-top: 5px; /* Space below heatmap */
+  margin-bottom: 5px; /* Space above color scale */
+  display: flex; /* Use flex to center content if needed */
+  justify-content: center; /* Center the box horizontally */
+  align-items: center; /* Center the box vertically */
+}
+
+#practice-safety-box {
+  border: 3px solid green; /* Default to safe */
+  box-sizing: border-box;
+  padding: 0px 5px; /* Some padding around the text */
+  height: 23px; /* Match theory box height */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#practice-safety-text {
+  color: green; /* Default to safe */
+  background-color: rgba(255, 255, 255, 0.8);
+  font-size: 13px;
+  text-align: center;
+  white-space: nowrap;
 }


### PR DESCRIPTION
From Google Jules:

1. Add 'safe in practice'/'unsafe in practice' indicator:
   - Displays below the heatmap, indicating if any critical 'emergency stop' patterns are misclassified as 'incinerate'.
   - Dynamically updates with network training.

2. Remove Regularization dropdowns:
   - Removed 'Regularization' and 'Regularization rate' controls from the UI.
   - Associated logic and state properties have been removed. Network now operates without L1/L2 regularization.

3. Modify Learning Rate dropdown highlighting:
   - When the learning rate is automatically adjusted due to zigzagging, only the dropdown input field itself will flash yellow.

4. Remove 'Test loss' display and line chart series:
   - Removed 'Test loss' text from the output metrics.
   - The line chart now only displays 'Training loss'.
   - Underlying chart logic updated to handle a single data series.