### PR TITLE
Add 'Avoid unsafe-in-theory' option to modify loss

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,6 +263,7 @@ limitations under the License.
             <div id="hovercard">
               <div style="font-size:10px">Click anywhere to edit.</div>
               <div><span class="type">Weight/Bias</span> is <span class="value">0.2</span><span><input type="number"/></span>.</div>
+              <div>Last change: <span class="last-change-value">0.00</span></div>
             </div>
             <div class="callout thumbnail">
               <svg viewBox="0 0 30 30">

--- a/index.html
+++ b/index.html
@@ -96,18 +96,17 @@ limitations under the License.
           </select>
         </div>
       </div>
-      <div class="control ui-theoretical-unsafety-importance">
-        <label for="theoretical-unsafety-importance-select">Importance of theoretical unsafety</label>
+      <div class="control ui-theoretical-unsafety-circles">
+        <label for="theoretical-unsafety-circles-select">Theoretical unsafety counts as</label>
         <div class="select">
-          <select id="theoretical-unsafety-importance-select">
-            <option value="0">0.0</option>
-            <option value="0.001">0.001</option>
-            <option value="0.003">0.003</option>
-            <option value="0.01">0.01</option>
-            <option value="0.03">0.03</option>
-            <option value="0.1">0.1</option>
-            <option value="0.3">0.3</option>
-            <option value="1">1.0</option>
+          <select id="theoretical-unsafety-circles-select">
+            <option value="0">0 circles</option>
+            <option value="1">1 circle</option>
+            <option value="2">2 circles</option>
+            <option value="4">4 circles</option>
+            <option value="8">8 circles</option>
+            <option value="16">16 circles</option>
+            <option value="32">32 circles</option>
           </select>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -96,11 +96,20 @@ limitations under the License.
           </select>
         </div>
       </div>
-      <div class="control ui-avoid-unsafe-in-theory">
-        <label for="avoid-unsafe-in-theory-checkbox" style="display: block; margin-bottom: 5px;">Avoid unsafe-in-theory</label>
-        <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="avoid-unsafe-in-theory-checkbox">
-          <input type="checkbox" id="avoid-unsafe-in-theory-checkbox" class="mdl-checkbox__input">
-        </label>
+      <div class="control ui-theoretical-unsafety-importance">
+        <label for="theoretical-unsafety-importance-select">Importance of theoretical unsafety</label>
+        <div class="select">
+          <select id="theoretical-unsafety-importance-select">
+            <option value="0">0.0</option>
+            <option value="0.001">0.001</option>
+            <option value="0.003">0.003</option>
+            <option value="0.01">0.01</option>
+            <option value="0.03">0.03</option>
+            <option value="0.1">0.1</option>
+            <option value="0.3">0.3</option>
+            <option value="1">1.0</option>
+          </select>
+        </div>
       </div>
       <div class="control ui-seed-input">
         <label for="userSeed">Seed</label>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,12 @@ limitations under the License.
           </select>
         </div>
       </div>
+      <div class="control ui-avoid-unsafe-in-theory">
+        <label for="avoid-unsafe-in-theory-checkbox" style="display: block; margin-bottom: 5px;">Avoid unsafe-in-theory</label>
+        <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="avoid-unsafe-in-theory-checkbox">
+          <input type="checkbox" id="avoid-unsafe-in-theory-checkbox" class="mdl-checkbox__input">
+        </label>
+      </div>
       <div class="control ui-seed-input">
         <label for="userSeed">Seed</label>
         <div style="display: flex; align-items: center;">

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -309,8 +309,6 @@ export function updateWeights(network: Node[][], learningRate: number,
         node.lastChange = biasChange;
         node.accInputDer = 0;
         node.numAccumulatedDers = 0;
-      } else {
-        node.lastChange = 0;
       }
       // Update the weights coming into this node.
       for (let j = 0; j < node.inputLinks.length; j++) {
@@ -344,8 +342,6 @@ export function updateWeights(network: Node[][], learningRate: number,
           link.lastChange = newLinkWeight - oldWeight;
           link.accErrorDer = 0;
           link.numAccumulatedDers = 0;
-        } else {
-          link.lastChange = 0; // No accumulated derivatives, so no change this step
         }
       }
     }

--- a/src/nn.ts
+++ b/src/nn.ts
@@ -48,6 +48,8 @@ export class Node {
   activation: ActivationFunction;
   /** Range of possible outputs of this node. */
   range: Range;
+  /** The last change applied to the bias of this node. */
+  lastChange: number = 0;
 
   /**
    * Creates a new node with the provided id and activation function.
@@ -127,6 +129,8 @@ export class Link {
   /** Number of accumulated derivatives since the last update. */
   numAccumulatedDers = 0;
   regularization: RegularizationFunction;
+  /** The last change applied to the weight of this link. */
+  lastChange: number = 0;
 
   /**
    * Constructs a link in the neural network initialized with random weight.
@@ -300,35 +304,48 @@ export function updateWeights(network: Node[][], learningRate: number,
       let node = currentLayer[i];
       // Update the node's bias.
       if (node.numAccumulatedDers > 0) {
-        node.bias -= learningRate * node.accInputDer / node.numAccumulatedDers;
+        let biasChange = -learningRate * node.accInputDer / node.numAccumulatedDers;
+        node.bias += biasChange;
+        node.lastChange = biasChange;
         node.accInputDer = 0;
         node.numAccumulatedDers = 0;
+      } else {
+        node.lastChange = 0;
       }
       // Update the weights coming into this node.
       for (let j = 0; j < node.inputLinks.length; j++) {
         let link = node.inputLinks[j];
         if (link.isDead) {
+          link.lastChange = 0; // Ensure dead links show no change
           continue;
         }
-        let regulDer = link.regularization ?
-            link.regularization.der(link.weight) : 0;
+        let oldWeight = link.weight;
+        let newLinkWeight = oldWeight; // Initialize with oldWeight
+
         if (link.numAccumulatedDers > 0) {
-          // Update the weight based on dE/dw.
-          link.weight = link.weight -
-              (learningRate / link.numAccumulatedDers) * link.accErrorDer;
-          // Further update the weight based on regularization.
-          let newLinkWeight = link.weight -
-              (learningRate * regularizationRate) * regulDer;
+          // Calculate change from error derivative
+          let weightUpdateErrorDer = (learningRate / link.numAccumulatedDers) * link.accErrorDer;
+          newLinkWeight -= weightUpdateErrorDer;
+
+          // Calculate change from regularization
+          let regulDer = link.regularization ?
+              link.regularization.der(oldWeight) : 0; // Regularization based on weight *before* this step's update
+          let weightUpdateReg = (learningRate * regularizationRate) * regulDer;
+          newLinkWeight -= weightUpdateReg;
+
           if (link.regularization === RegularizationFunction.L1 &&
-              link.weight * newLinkWeight < 0) {
-            // The weight crossed 0 due to the regularization term. Set it to 0.
-            link.weight = 0;
+              oldWeight * newLinkWeight < 0) { // Check if sign changed due to combined updates
+            // The weight crossed 0. Set it to 0.
+            newLinkWeight = 0;
             link.isDead = true;
-          } else {
-            link.weight = newLinkWeight;
           }
+
+          link.weight = newLinkWeight;
+          link.lastChange = newLinkWeight - oldWeight;
           link.accErrorDer = 0;
           link.numAccumulatedDers = 0;
+        } else {
+          link.lastChange = 0; // No accumulated derivatives, so no change this step
         }
       }
     }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -499,10 +499,10 @@ function makeGUI() {
   // Check/uncheck the checkbox according to the current state.
   showTestData.property("checked", state.showTestData);
 
-  // Theoretical unsafety importance dropdown
-  let theoreticalUnsafetyImportanceSelect = d3.select("#theoretical-unsafety-importance-select")
+  // Theoretical unsafety circles dropdown
+  let theoreticalUnsafetyCirclesSelect = d3.select("#theoretical-unsafety-circles-select")
     .on("change", function() {
-      state.theoreticalUnsafetyImportance = +this.value;
+      state.theoreticalUnsafetyCircles = +this.value;
       state.serialize();
       userHasInteracted();
       // We need to re-calculate loss and potentially update UI, so oneStep() is appropriate
@@ -511,7 +511,7 @@ function makeGUI() {
       oneStep();
     });
   // Set the dropdown according to the current state.
-  theoreticalUnsafetyImportanceSelect.property("value", state.theoreticalUnsafetyImportance);
+  theoreticalUnsafetyCirclesSelect.property("value", state.theoreticalUnsafetyCircles);
 
   state.noise = 0;
 
@@ -1043,17 +1043,30 @@ function getLoss(network: nn.Node[][], dataPoints: Example2D[]): number {
     let output = nn.forwardProp(network, input);
     loss += nn.Errors.SQUARE.error(output, dataPoint.label);
   }
-  let calculatedLoss = loss / dataPoints.length;
+  // `loss` here is the sum of squared errors from dataPoints
+  let totalLoss = loss; // Initialize totalLoss with the sum of errors from actual data points
 
-  const importanceMultiplier = state.theoreticalUnsafetyImportance;
-  if (importanceMultiplier > 0) {
+  const numCircles = state.theoreticalUnsafetyCircles;
+  if (numCircles > 0) {
     const outputNode = network[network.length - 1][0];
     if (outputNode && outputNode.range) {
-      // Add max of output node's range multiplied by the importance factor
-      calculatedLoss += outputNode.range[1] * importanceMultiplier;
+      const maxOutputRange = outputNode.range[1];
+      // Target for theoretical safety is -1.0 (output for a "safe" classification)
+      const theoreticalTarget = -1.0;
+      // Calculate the squared error for the theoretical unsafety
+      const theoreticalError = nn.Errors.SQUARE.error(maxOutputRange, theoreticalTarget);
+      // Add this error, multiplied by the number of equivalent circles, to the total loss
+      totalLoss += theoreticalError * numCircles;
     }
   }
-  return calculatedLoss;
+
+  const effectiveNumDataPoints = dataPoints.length + numCircles;
+
+  if (effectiveNumDataPoints === 0) {
+    return 0; // Avoid division by zero if there are no data points and no circles
+  }
+
+  return totalLoss / effectiveNumDataPoints;
 }
 
 function updateUI(firstStep = false) {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -499,10 +499,10 @@ function makeGUI() {
   // Check/uncheck the checkbox according to the current state.
   showTestData.property("checked", state.showTestData);
 
-  // Avoid unsafe-in-theory checkbox
-  let avoidUnsafeInTheoryCheckbox = d3.select("#avoid-unsafe-in-theory-checkbox")
+  // Theoretical unsafety importance dropdown
+  let theoreticalUnsafetyImportanceSelect = d3.select("#theoretical-unsafety-importance-select")
     .on("change", function() {
-      state.avoidUnsafeInTheory = this.checked;
+      state.theoreticalUnsafetyImportance = +this.value;
       state.serialize();
       userHasInteracted();
       // We need to re-calculate loss and potentially update UI, so oneStep() is appropriate
@@ -510,8 +510,8 @@ function makeGUI() {
       // If playing, it will continue playing but with the new loss consideration.
       oneStep();
     });
-  // Check/uncheck the checkbox according to the current state.
-  avoidUnsafeInTheoryCheckbox.property("checked", state.avoidUnsafeInTheory);
+  // Set the dropdown according to the current state.
+  theoreticalUnsafetyImportanceSelect.property("value", state.theoreticalUnsafetyImportance);
 
   state.noise = 0;
 
@@ -1045,10 +1045,12 @@ function getLoss(network: nn.Node[][], dataPoints: Example2D[]): number {
   }
   let calculatedLoss = loss / dataPoints.length;
 
-  if (state.avoidUnsafeInTheory) {
+  const importanceMultiplier = state.theoreticalUnsafetyImportance;
+  if (importanceMultiplier > 0) {
     const outputNode = network[network.length - 1][0];
     if (outputNode && outputNode.range) {
-      calculatedLoss += outputNode.range[1]; // Add max of output node's range
+      // Add max of output node's range multiplied by the importance factor
+      calculatedLoss += outputNode.range[1] * importanceMultiplier;
     }
   }
   return calculatedLoss;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -499,6 +499,20 @@ function makeGUI() {
   // Check/uncheck the checkbox according to the current state.
   showTestData.property("checked", state.showTestData);
 
+  // Avoid unsafe-in-theory checkbox
+  let avoidUnsafeInTheoryCheckbox = d3.select("#avoid-unsafe-in-theory-checkbox")
+    .on("change", function() {
+      state.avoidUnsafeInTheory = this.checked;
+      state.serialize();
+      userHasInteracted();
+      // We need to re-calculate loss and potentially update UI, so oneStep() is appropriate
+      // If the simulation is paused, oneStep() will execute once.
+      // If playing, it will continue playing but with the new loss consideration.
+      oneStep();
+    });
+  // Check/uncheck the checkbox according to the current state.
+  avoidUnsafeInTheoryCheckbox.property("checked", state.avoidUnsafeInTheory);
+
   state.noise = 0;
 
   let activationDropdown = d3.select("#activations").on("change", function() {
@@ -1029,7 +1043,15 @@ function getLoss(network: nn.Node[][], dataPoints: Example2D[]): number {
     let output = nn.forwardProp(network, input);
     loss += nn.Errors.SQUARE.error(output, dataPoint.label);
   }
-  return loss / dataPoints.length;
+  let calculatedLoss = loss / dataPoints.length;
+
+  if (state.avoidUnsafeInTheory) {
+    const outputNode = network[network.length - 1][0];
+    if (outputNode && outputNode.range) {
+      calculatedLoss += outputNode.range[1]; // Add max of output node's range
+    }
+  }
+  return calculatedLoss;
 }
 
 function updateUI(firstStep = false) {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -938,6 +938,15 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
   hovercard.select(".value")
     .style("display", null)
     .text(value.toPrecision(2));
+
+  // Display last change
+  let lastChange = (type === HoverType.WEIGHT) ?
+    (nodeOrLink as nn.Link).lastChange :
+    (nodeOrLink as nn.Node).lastChange;
+
+  hovercard.select(".last-change-value")
+    .text(lastChange.toPrecision(2)); // Using toPrecision for consistency
+
   hovercard.select("input")
     .property("value", value.toPrecision(2))
     .style("display", "none");

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -335,8 +335,6 @@ let lossTest = 0;
 let player = new Player();
 let lineChart = new AppendingLineChart(d3.select("#linechart"),
     ["#777"]); // Only one color for training loss
-let recentTrainLosses: number[] = [];
-const LEARNING_RATES = [0.00001, 0.0001, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1, 3, 10];
 
 function enableFeaturesForDataset(dataset: DataGenerator) {
   // First, disable all feature inputs
@@ -945,7 +943,7 @@ function updateHoverCard(type: HoverType, nodeOrLink?: nn.Node | nn.Link,
     (nodeOrLink as nn.Node).lastChange;
 
   hovercard.select(".last-change-value")
-    .text(lastChange.toPrecision(2)); // Using toPrecision for consistency
+    .text(lastChange); // Display raw value for debugging
 
   hovercard.select("input")
     .property("value", value.toPrecision(2))
@@ -1252,47 +1250,6 @@ function oneStep(): void {
   lossTrain = getLoss(network, trainData);
   lossTest = getLoss(network, testData);
 
-  // Zigzag detection logic
-  if (trainData.length > 0) { // Only run if there's training data
-    recentTrainLosses.push(lossTrain);
-    if (recentTrainLosses.length > 10) {
-      recentTrainLosses.shift(); // Keep only the last 10 losses
-    }
-
-    if (recentTrainLosses.length === 10 && iter >= state.cooldownActiveUntilIter) {
-      let increases = 0;
-      for (let k = 1; k < recentTrainLosses.length; k++) {
-        if (recentTrainLosses[k] > recentTrainLosses[k - 1]) {
-          increases++;
-        }
-      }
-
-      if (increases >= 5) {
-        console.log(`Zigzag detected at iteration ${iter}. Increases: ${increases}. Current LR: ${state.learningRate}`);
-        const currentLRIndex = LEARNING_RATES.indexOf(state.learningRate);
-        if (currentLRIndex > 0) { // Ensure it's not already the smallest
-          const newLearningRate = LEARNING_RATES[currentLRIndex - 1];
-          state.learningRate = newLearningRate;
-          // Update the UI dropdown
-          (d3.select("#learningRate").node() as HTMLSelectElement).value = newLearningRate.toString();
-          console.log(`Learning rate reduced to ${newLearningRate}`);
-          state.cooldownActiveUntilIter = iter + 30; // Start cooldown
-
-          // Highlight the learning rate dropdown input element
-          const lrInputElement = d3.select("#learningRate").node() as HTMLElement;
-          if (lrInputElement) {
-            lrInputElement.classList.add("lr-input-highlight");
-            setTimeout(() => {
-              lrInputElement.classList.remove("lr-input-highlight");
-            }, 1000); // Highlight for 1 second
-          }
-        } else {
-          console.log("Learning rate already at minimum.");
-        }
-      }
-    }
-  }
-
   updateUI();
 }
 
@@ -1322,8 +1279,6 @@ function reset(onStartup=false, hardcodeWeightsOption?:boolean) { // hardcodeWei
   // Set learning rate to 0.3 and update UI
   state.learningRate = 0.3;
   d3.select("#learningRate").property("value", "0.3");
-  recentTrainLosses = []; // Also clear recent losses on reset
-  state.cooldownActiveUntilIter = 0; // Reset cooldown
 
 
   // Determine if weights should be hardcoded

--- a/src/state.ts
+++ b/src/state.ts
@@ -117,7 +117,7 @@ export class State {
     {name: "dataCollapsed", type: Type.BOOLEAN},
     {name: "featuresCollapsed", type: Type.BOOLEAN},
     {name: "outputCollapsed", type: Type.BOOLEAN},
-    {name: "avoidUnsafeInTheory", type: Type.BOOLEAN}
+    {name: "theoreticalUnsafetyImportance", type: Type.NUMBER}
   ];
 
   [key: string]: any;
@@ -153,7 +153,7 @@ export class State {
   dataCollapsed = false;
   featuresCollapsed = false;
   outputCollapsed = false;
-  avoidUnsafeInTheory = false;
+  theoreticalUnsafetyImportance = 0.0;
 
   /**
    * Deserializes the state from the url hash.

--- a/src/state.ts
+++ b/src/state.ts
@@ -116,7 +116,8 @@ export class State {
     {name: "hideText", type: Type.BOOLEAN},
     {name: "dataCollapsed", type: Type.BOOLEAN},
     {name: "featuresCollapsed", type: Type.BOOLEAN},
-    {name: "outputCollapsed", type: Type.BOOLEAN}
+    {name: "outputCollapsed", type: Type.BOOLEAN},
+    {name: "avoidUnsafeInTheory", type: Type.BOOLEAN}
   ];
 
   [key: string]: any;
@@ -152,6 +153,7 @@ export class State {
   dataCollapsed = false;
   featuresCollapsed = false;
   outputCollapsed = false;
+  avoidUnsafeInTheory = false;
 
   /**
    * Deserializes the state from the url hash.

--- a/src/state.ts
+++ b/src/state.ts
@@ -117,7 +117,7 @@ export class State {
     {name: "dataCollapsed", type: Type.BOOLEAN},
     {name: "featuresCollapsed", type: Type.BOOLEAN},
     {name: "outputCollapsed", type: Type.BOOLEAN},
-    {name: "theoreticalUnsafetyImportance", type: Type.NUMBER}
+    {name: "theoreticalUnsafetyCircles", type: Type.NUMBER}
   ];
 
   [key: string]: any;
@@ -153,7 +153,7 @@ export class State {
   dataCollapsed = false;
   featuresCollapsed = false;
   outputCollapsed = false;
-  theoreticalUnsafetyImportance = 0.0;
+  theoreticalUnsafetyCircles = 0;
 
   /**
    * Deserializes the state from the url hash.

--- a/src/state.ts
+++ b/src/state.ts
@@ -99,7 +99,6 @@ export class State {
     {name: "seed", type: Type.STRING},
     {name: "discretize", type: Type.BOOLEAN},
     {name: "percTrainData", type: Type.NUMBER},
-    {name: "cooldownActiveUntilIter", type: Type.NUMBER},
     {name: "x", type: Type.BOOLEAN},
     {name: "y", type: Type.BOOLEAN},
     {name: "bit0", type: Type.BOOLEAN},
@@ -149,7 +148,6 @@ export class State {
   dataset: dataset.DataGenerator = dataset.classifyParityData;
   regDataset: dataset.DataGenerator = dataset.regressPlane;
   seed: string;
-  cooldownActiveUntilIter = 0;
   dataCollapsed = false;
   featuresCollapsed = false;
   outputCollapsed = false;


### PR DESCRIPTION
From Google Jules:

This commit introduces a new checkbox in the header: 'Avoid unsafe-in-theory'.

When this option is checked:
- The state `avoidUnsafeInTheory` is set to true.
- The maximum value of the output node's calculated range (`outputNode.range[1]`) is added to the training loss.

This change allows you to penalize the network for being 'unsafe in theory', encouraging it to find configurations that are provably safe for critical inputs.