### PR TITLE
Refactor: Randomize the input sample for weight updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,8 @@ limitations under the License.
             <div class="output-stats train">
               <span>Training loss</span>
               <div class="value" id="loss-train"></div>
+              <span>Increases</span>
+              <div class="value" id="loss-increases"></div>
             </div>
             <div id="practice-safety-container"></div>
             <div id="linechart"></div>

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@ limitations under the License.
               <span>Training loss</span>
               <div class="value" id="loss-train"></div>
               <span>Increases</span>
-              <div class="value" id="loss-increases"></div>
+              <span class="value" id="loss-increases"></span>
             </div>
             <div id="practice-safety-container"></div>
             <div id="linechart"></div>

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -971,6 +971,15 @@ function updateUI(firstStep = false) {
   d3.select("#loss-train").text(humanReadable(lossTrain));
   // d3.select("#loss-test").text(humanReadable(lossTest)); // Removed
   d3.select("#iter-number").text(addCommas(zeroPad(iter)));
+  let increases = 0;
+  if (recentTrainLosses.length === 10) {
+    for (let k = 1; k < recentTrainLosses.length; k++) {
+      if (recentTrainLosses[k] > recentTrainLosses[k - 1]) {
+        increases++;
+      }
+    }
+  }
+  d3.select("#loss-increases").text(increases);
   updateCodeDisplay(); // Update code display whenever UI refreshes
 
   // Handle "unsafe in practice" box
@@ -1106,7 +1115,7 @@ function oneStep(): void {
         }
       }
 
-      if (increases >= 5) {
+      if (increases >= 4) {
         console.log(`Zigzag detected at iteration ${iter}. Increases: ${increases}. Current LR: ${state.learningRate}`);
         const currentLRIndex = LEARNING_RATES.indexOf(state.learningRate);
         if (currentLRIndex > 0) { // Ensure it's not already the smallest

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1071,14 +1071,22 @@ function constructInput(x: number, y: number): number[] {
 function oneStep(): void {
   iter++;
   let currentLearningRate = state.learningRate;
-  trainData.forEach((point, i) => {
+  // Step 1: Shuffle the training data
+  shuffle(trainData);
+
+  // Step 2: Create a mini-batch of 10 random samples
+  const miniBatch = trainData.slice(0, 10);
+
+  // Step 3: Perform forward and backward propagation on the mini-batch
+  miniBatch.forEach(point => {
     let input = constructInput(point.x, point.y);
     nn.forwardProp(network, input);
     nn.backProp(network, point.label, nn.Errors.SQUARE);
-    if ((i + 1) % 10 === 0) {
-      nn.updateWeights(network, currentLearningRate, 0, Activations.RELU); // Regularization rate is now 0
-    }
   });
+
+  // Step 4: Update weights once for the entire mini-batch
+  nn.updateWeights(network, currentLearningRate, 0, Activations.RELU);
+
   // Compute the loss.
   lossTrain = getLoss(network, trainData);
   lossTest = getLoss(network, testData);


### PR DESCRIPTION
Instead of looping over every input in order and updating the weights every 10 inputs, this change shuffles the training data, picks 10 random inputs, and updates the weights a single time for the batch. This should make the training process more robust.