### PR TITLE
Adjust learning rate based on loss

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1083,46 +1083,13 @@ function oneStep(): void {
   lossTrain = getLoss(network, trainData);
   lossTest = getLoss(network, testData);
 
-  // Zigzag detection logic
-  if (trainData.length > 0) { // Only run if there's training data
-    recentTrainLosses.push(lossTrain);
-    if (recentTrainLosses.length > 10) {
-      recentTrainLosses.shift(); // Keep only the last 10 losses
-    }
-
-    if (recentTrainLosses.length === 10 && iter >= state.cooldownActiveUntilIter) {
-      let increases = 0;
-      for (let k = 1; k < recentTrainLosses.length; k++) {
-        if (recentTrainLosses[k] > recentTrainLosses[k - 1]) {
-          increases++;
-        }
-      }
-
-      if (increases >= 5) {
-        console.log(`Zigzag detected at iteration ${iter}. Increases: ${increases}. Current LR: ${state.learningRate}`);
-        const currentLRIndex = LEARNING_RATES.indexOf(state.learningRate);
-        if (currentLRIndex > 0) { // Ensure it's not already the smallest
-          const newLearningRate = LEARNING_RATES[currentLRIndex - 1];
-          state.learningRate = newLearningRate;
-          // Update the UI dropdown
-          (d3.select("#learningRate").node() as HTMLSelectElement).value = newLearningRate.toString();
-          console.log(`Learning rate reduced to ${newLearningRate}`);
-          state.cooldownActiveUntilIter = iter + 30; // Start cooldown
-
-          // Highlight the learning rate dropdown input element
-          const lrInputElement = d3.select("#learningRate").node() as HTMLElement;
-          if (lrInputElement) {
-            lrInputElement.classList.add("lr-input-highlight");
-            setTimeout(() => {
-              lrInputElement.classList.remove("lr-input-highlight");
-            }, 1000); // Highlight for 1 second
-          }
-        } else {
-          console.log("Learning rate already at minimum.");
-        }
-      }
-    }
+  if (lossTrain <= 0.25) {
+    state.learningRate = 0.03;
+  } else if (lossTrain <= 0.5) {
+    state.learningRate = 0.1;
   }
+  // Update the UI dropdown
+  (d3.select("#learningRate").node() as HTMLSelectElement).value = state.learningRate.toString();
 
   updateUI();
 }


### PR DESCRIPTION
From Google Jules:

Removes the zigzag detection logic and replaces it with a new learning rate adjustment feature.

The learning rate is now adjusted based on the following rules:
- When the loss becomes 0.5 or less, the learning rate is reduced to 0.1.
- When the loss becomes 0.25 or less, the learning rate is reduced to 0.03.