### PR TITLE
Correct arrow rotation for collapsible sections

### DIFF
--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1321,7 +1321,10 @@ function initCollapsibleSections() {
     // Apply initial collapsed state
     if (state[section.stateKey]) {
       column.classed('collapsed', true);
-      collapseButton.style('transform', 'rotate(-90deg)');
+      collapseButton.style('transform', 'rotate(0deg)');
+    } else {
+      column.classed('collapsed', false);
+      collapseButton.style('transform', 'rotate(90deg)');
     }
   });
 }
@@ -1333,13 +1336,14 @@ function toggleSection(selector: string, stateKey: string) {
 
   // Update state
   state[stateKey] = !isCollapsed;
+  state.serialize();
 
   // Toggle collapsed class
   column.classed('collapsed', !isCollapsed);
 
   if (!isCollapsed) {
-    collapseButton.style('transform', 'rotate(90deg)');
-  } else {
     collapseButton.style('transform', 'rotate(0deg)');
+  } else {
+    collapseButton.style('transform', 'rotate(90deg)');
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -91,9 +91,11 @@ export class State {
     {name: "safetyImportance", type: Type.NUMBER},
     {name: "networkShape", type: Type.ARRAY_NUMBER},
     {name: "seed", type: Type.STRING},
-    {name: "dataCollapsed", type: Type.BOOLEAN},
+    {name: "instructionsCollapsed", type: Type.BOOLEAN},
+    {name: "aiSafetyCollapsed", type: Type.BOOLEAN},
     {name: "featuresCollapsed", type: Type.BOOLEAN},
-    {name: "outputCollapsed", type: Type.BOOLEAN}
+    {name: "outputCollapsed", type: Type.BOOLEAN},
+    {name: "codeCollapsed", type: Type.BOOLEAN}
   ];
 
   [key: string]: any;
@@ -102,9 +104,11 @@ export class State {
   networkShape: number[] = [8, 8];
   seed: string;
   cooldownActiveUntilIter = 0;
-  dataCollapsed = false;
+  instructionsCollapsed = false;
+  aiSafetyCollapsed = false;
   featuresCollapsed = false;
   outputCollapsed = false;
+  codeCollapsed = false;
 
   /**
    * Deserializes the state from the url hash.


### PR DESCRIPTION
From Google Jules:

This commit fixes a bug where the arrow for a collapsed section would point upwards on page reload. It also addresses several related issues:

- The initial rotation for both collapsed and expanded sections is now set correctly.
- The toggle logic for collapsing/expanding sections is fixed.
- State serialization is now correctly handled for all collapsible sections, ensuring their state is preserved across reloads.